### PR TITLE
Avoid undefined attendees array

### DIFF
--- a/src/app/profil/[userId]/page.tsx
+++ b/src/app/profil/[userId]/page.tsx
@@ -64,7 +64,7 @@ export default function UserProfilePage() {
           const data = doc.data() as BathEntry;
           logEntries.push({ ...data, id: doc.id });
            if (data.type === 'planned') {
-            data.attendees.forEach(uid => attendeeIdsToFetch.add(uid));
+            data.attendees?.forEach(uid => attendeeIdsToFetch.add(uid));
           }
         });
         setBathLog(logEntries);
@@ -253,15 +253,15 @@ export default function UserProfilePage() {
                       <div className="space-y-2 text-sm">
                         <div className="flex items-center">
                           <Users className="h-4 w-4 mr-2 text-muted-foreground" />
-                          <span>{bath.attendees.length} påmeldt.</span>
+                          <span>{bath.attendees ? bath.attendees.length : 0} påmeldt.</span>
                         </div>
-                        {bath.attendees.length > 0 && <p className="text-muted-foreground">Deltakere: {bath.attendees.map(uid => attendeesDetails[uid]?.name || '...').join(', ')}</p>}
+                        {bath.attendees && bath.attendees.length > 0 && <p className="text-muted-foreground">Deltakere: {bath.attendees.map(uid => attendeesDetails[uid]?.name || '...').join(', ')}</p>}
 
                         {loggedInUser && loggedInUser.uid === bath.userId ? (
                            <Button size="sm" variant="outline" className="mt-2 w-full sm:w-auto" disabled>
                              <Info className="mr-2 h-4 w-4" /> Du arrangerer
                            </Button>
-                        ) : loggedInUser && bath.attendees.includes(loggedInUser.uid) ? (
+                        ) : loggedInUser && bath.attendees && bath.attendees.includes(loggedInUser.uid) ? (
                            <Button 
                              size="sm" 
                              variant="outline" 

--- a/src/components/app/real-time-feed.tsx
+++ b/src/components/app/real-time-feed.tsx
@@ -51,7 +51,7 @@ export function RealTimeFeed() {
         const data = doc.data() as BathEntry;
         items.push({ ...data, id: doc.id });
         if (data.type === 'planned') {
-            data.attendees.forEach(uid => attendeeIdsToFetch.add(uid));
+            data.attendees?.forEach(uid => attendeeIdsToFetch.add(uid));
         }
       });
 
@@ -206,8 +206,8 @@ export function RealTimeFeed() {
               <div className="space-y-2">
                 <h3 className="font-semibold text-md flex items-center"><CalendarCheck className="h-5 w-5 mr-2 text-primary" /> {entry.description}</h3>
                 {entry.location && <p className="text-sm text-muted-foreground">Sted: {entry.location}</p>}
-                <p className="text-sm text-muted-foreground">Antall påmeldte: {entry.attendees.length}</p>
-                {entry.attendees.length > 0 && (
+                <p className="text-sm text-muted-foreground">Antall påmeldte: {entry.attendees ? entry.attendees.length : 0}</p>
+                {entry.attendees && entry.attendees.length > 0 && (
                   <p className="text-sm text-muted-foreground">
                     Deltakere: {entry.attendees.map(uid => attendeesDetails[uid]?.name || 'Laster...').join(', ')}
                   </p>
@@ -233,15 +233,15 @@ export function RealTimeFeed() {
               <div className="flex w-full justify-between items-center">
                 <div className="flex items-center text-sm text-muted-foreground">
                   <Users className="h-4 w-4 mr-2" />
-                  <span>{entry.attendees.length} påmeldt</span>
+                  <span>{entry.attendees ? entry.attendees.length : 0} påmeldt</span>
                 </div>
                 {currentUser && entry.userId === currentUser.uid ? (
                    <Button size="sm" variant="outline" disabled>
                      <Info className="h-4 w-4 mr-2" /> Du arrangerer
                    </Button>
-                ) : currentUser && entry.attendees.includes(currentUser.uid) ? (
-                  <Button 
-                    size="sm" 
+                ) : currentUser && entry.attendees && entry.attendees.includes(currentUser.uid) ? (
+                  <Button
+                    size="sm"
                     variant="outline"
                     onClick={() => handleSignOff(entry.id, entry.description)}
                   >


### PR DESCRIPTION
## Summary
- guard against undefined attendees arrays in real-time feed and user profile
- skip fetching attendee details when array is missing

## Testing
- `npm run lint` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `npm run typecheck` *(fails: existing type errors)*