### PR TITLE
Fix leaderboard page dynamic setting

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,6 +1,8 @@
 
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { UserProgress } from "@/components/app/user-progress";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Trophy, Waves } from "lucide-react";


### PR DESCRIPTION
## Summary
- ensure the leaderboard page is always rendered dynamically

## Testing
- `npm run lint` *(fails: getaddrinfo ENOTFOUND)*
- `npm run typecheck` *(fails: several TS errors in other files)*