### PR TITLE
Handle Firestore timestamps

### DIFF
--- a/src/app/profil/[userId]/page.tsx
+++ b/src/app/profil/[userId]/page.tsx
@@ -13,7 +13,7 @@ import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth, type UserProfile } from "@/contexts/auth-context";
 import { db } from "@/lib/firebase";
-import { doc, getDoc, collection, query, where, orderBy, onSnapshot, updateDoc, arrayUnion, arrayRemove } from "firebase/firestore";
+import { doc, getDoc, collection, query, where, orderBy, onSnapshot, updateDoc, arrayUnion, arrayRemove, Timestamp } from "firebase/firestore";
 import { format as formatDateFns } from "date-fns";
 import { nb } from "date-fns/locale";
 import Link from "next/link";
@@ -140,11 +140,15 @@ export default function UserProfilePage() {
     }
   };
 
-  const formatDateForDisplay = (dateString: string) => {
+  const formatDateForDisplay = (dateInput: string | Timestamp) => {
     try {
-      return formatDateFns(new Date(dateString), "d. MMMM yyyy", { locale: nb });
+      const date =
+        dateInput instanceof Timestamp
+          ? dateInput.toDate()
+          : new Date(dateInput);
+      return formatDateFns(date, "d. MMMM yyyy", { locale: nb });
     } catch (e) {
-      return dateString; 
+      return String(dateInput);
     }
   };
 

--- a/src/components/app/real-time-feed.tsx
+++ b/src/components/app/real-time-feed.tsx
@@ -14,7 +14,7 @@ import type { BathEntry, PlannedBath } from "@/types/bath";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth, type UserProfile } from "@/contexts/auth-context";
 import { db } from "@/lib/firebase";
-import { collection, query, orderBy, onSnapshot, doc, updateDoc, arrayUnion, arrayRemove, getDoc } from "firebase/firestore";
+import { collection, query, orderBy, onSnapshot, doc, updateDoc, arrayUnion, arrayRemove, getDoc, Timestamp } from "firebase/firestore";
 import { format } from "date-fns";
 import { nb } from "date-fns/locale";
 
@@ -146,11 +146,15 @@ export function RealTimeFeed() {
     );
   }
   
-  const formatDateForDisplay = (dateString: string) => {
+  const formatDateForDisplay = (dateInput: string | Timestamp) => {
     try {
-      return format(new Date(dateString), "d. MMMM yyyy", { locale: nb });
+      const date =
+        dateInput instanceof Timestamp
+          ? dateInput.toDate()
+          : new Date(dateInput);
+      return format(date, "d. MMMM yyyy", { locale: nb });
     } catch (e) {
-      return dateString; // Fallback if date is not in expected 'yyyy-MM-dd' format
+      return String(dateInput); // Fallback if parsing fails
     }
   };
 


### PR DESCRIPTION
## Summary
- support Firestore `Timestamp` objects when formatting dates

## Testing
- `npm run typecheck` *(fails: userProfile is possibly null)*
- `npm run lint` *(fails to download @next/swc due to network)*