### PR TITLE
Ensure imageUrl optional when logging baths

### DIFF
--- a/src/components/app/bath-logging-form.tsx
+++ b/src/components/app/bath-logging-form.tsx
@@ -193,10 +193,10 @@ export function BathLoggingForm() {
         location: data.location || "",
         waterTemperature: data.waterTemperature || null,
         comments: data.comments || "",
-        imageUrl: imageUrl,
+        ...(imageUrl ? { imageUrl } : {}),
         reactions: { thumbsUp: 0, heart: 0, party: 0 },
         commentCount: 0,
-        createdAt: Date.now(), 
+        createdAt: Date.now(),
         type: 'logged',
     };
 


### PR DESCRIPTION
## Summary
- omit `imageUrl` from logged bath when no image provided

## Testing
- `npm run lint` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `npm run typecheck` *(fails: existing TypeScript errors)*
