### PR TITLE
Fix Firestore rule for first bath attendee

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -22,8 +22,9 @@ service cloud.firestore {
       allow update: if request.auth != null && (
         request.auth.uid == resource.data.userId || (
           request.resource.data.keys().hasOnly(['attendees']) && (
-            request.resource.data.attendees.diff(resource.data.attendees).added().hasOnly([request.auth.uid]) ||
-            request.resource.data.attendees.diff(resource.data.attendees).removed().hasOnly([request.auth.uid])
+            let current = ('attendees' in resource.data) ? resource.data.attendees : [];
+            let diff = request.resource.data.attendees.diff(current);
+            diff.added().hasOnly([request.auth.uid]) || diff.removed().hasOnly([request.auth.uid])
           )
         )
       );


### PR DESCRIPTION
## Summary
- allow first attendee to join a bath by handling missing `attendees` field

## Testing
- `npm run lint` *(fails: fetch failed for @next/swc)*
- `npm run typecheck`
