### PR TITLE
Allow Firebase Storage images

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,11 @@ const nextConfig: NextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'firebasestorage.googleapis.com',
+        pathname: '/v0/b/badekompis.firebasestorage.app/**',
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- allow Firebase Storage images in `next.config.ts`

## Testing
- `npm run lint` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `npm run typecheck`
