### PR TITLE
Add navigation badges

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Waves } from 'lucide-react';
 import { ClientLayoutWrapper } from '@/components/layout/client-layout-wrapper';
 import { AuthProvider } from '@/contexts/auth-context'; // Import AuthProvider
+import { NotificationProvider } from '@/contexts/notification-context';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -31,6 +32,7 @@ export default function RootLayout({
     <html lang="nb">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}>
         <AuthProvider> {/* Wrap with AuthProvider */}
+          <NotificationProvider>
           <header className="bg-primary text-primary-foreground py-4 px-4 md:px-8 shadow-md sticky top-0 z-40">
             <div className="container mx-auto flex items-center justify-center">
               <div className="flex items-center gap-2 md:gap-3">
@@ -43,6 +45,7 @@ export default function RootLayout({
             {children}
           </ClientLayoutWrapper>
           <Toaster />
+          </NotificationProvider>
         </AuthProvider> {/* Close AuthProvider */}
       </body>
     </html>

--- a/src/components/app/real-time-feed.tsx
+++ b/src/components/app/real-time-feed.tsx
@@ -14,6 +14,7 @@ import type { BathEntry, PlannedBath } from "@/types/bath";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth, type UserProfile } from "@/contexts/auth-context";
 import { db } from "@/lib/firebase";
+import { useNotifications } from "@/contexts/notification-context";
 import { collection, query, orderBy, onSnapshot, doc, updateDoc, arrayUnion, arrayRemove, getDoc, Timestamp, increment } from "firebase/firestore";
 
 import { CommentsDialog } from "./comments-dialog";
@@ -36,6 +37,7 @@ interface AttendeeDetails {
 export function RealTimeFeed() {
   const { toast } = useToast();
   const { currentUser, userProfile, loading: authLoading } = useAuth();
+  const { markFeedSeen } = useNotifications();
   const [feedItems, setFeedItems] = useState<BathEntry[]>([]);
   const [attendeesDetails, setAttendeesDetails] = useState<AttendeeDetails>({});
   const [feedLoading, setFeedLoading] = useState(true);
@@ -84,6 +86,12 @@ export function RealTimeFeed() {
 
     return () => unsubscribe();
   }, [toast]); // Removed attendeesDetails from dependency array to prevent potential infinite loop
+
+  useEffect(() => {
+    if (!feedLoading) {
+      markFeedSeen();
+    }
+  }, [feedLoading, markFeedSeen, feedItems]);
 
   const handleSignUp = async (plannedBathId: string, bathDescription: string) => {
     if (!currentUser) {

--- a/src/components/app/upcoming-planned-baths.tsx
+++ b/src/components/app/upcoming-planned-baths.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from "react";
 import { useAuth, type UserProfile } from "@/contexts/auth-context";
 import { useToast } from "@/hooks/use-toast";
 import { db } from "@/lib/firebase";
+import { useNotifications } from "@/contexts/notification-context";
 import { collection, query, orderBy, onSnapshot, doc, updateDoc, arrayUnion, arrayRemove, getDoc } from "firebase/firestore";
 import type { BathEntry, PlannedBath } from "@/types/bath";
 import { format } from "date-fns";
@@ -24,6 +25,7 @@ interface AttendeeDetails {
 export function UpcomingPlannedBaths() {
   const { toast } = useToast();
   const { currentUser, loading: authLoading } = useAuth();
+  const { markPlannedSeen } = useNotifications();
   const [baths, setBaths] = useState<PlannedBath[]>([]);
   const [attendeesDetails, setAttendeesDetails] = useState<AttendeeDetails>({});
   const [loadingBaths, setLoadingBaths] = useState(true);
@@ -74,6 +76,12 @@ export function UpcomingPlannedBaths() {
 
     return () => unsubscribe();
   }, [toast]);
+
+  useEffect(() => {
+    if (!loadingBaths) {
+      markPlannedSeen();
+    }
+  }, [loadingBaths, markPlannedSeen, baths]);
 
   const handleSignUp = async (bathId: string, description: string) => {
     if (!currentUser) {

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { Home, ClipboardPlus, CalendarPlus, Trophy, User, LogIn } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/contexts/auth-context";
+import { useNotifications } from "@/contexts/notification-context";
 
 const navItemsBase = [
   { href: "/", label: "Feed", icon: Home, requiresAuth: false },
@@ -18,6 +19,7 @@ const navItemsBase = [
 export function Navbar() {
   const pathname = usePathname();
   const { currentUser, loading } = useAuth();
+  const { newFeed, newPlanned } = useNotifications();
 
   const getNavItems = () => {
     let items = navItemsBase;
@@ -48,6 +50,9 @@ export function Navbar() {
       <div className="container mx-auto flex justify-around items-center h-16 max-w-md">
         {visibleNavItems.map((item) => {
           const isActive = pathname === item.href || (item.href === "/profil" && pathname.startsWith("/profil/"));
+          const showBadge =
+            (item.href === "/" && newFeed) ||
+            (item.href === "/planlagte-bad" && newPlanned);
           return (
             <Link
               key={item.href}
@@ -58,7 +63,10 @@ export function Navbar() {
               )}
               aria-current={isActive ? "page" : undefined}
             >
-              <item.icon className={cn("h-6 w-6 mb-0.5", isActive ? "stroke-[2.5px]" : "")} />
+              <div className="relative">
+                <item.icon className={cn("h-6 w-6 mb-0.5", isActive ? "stroke-[2.5px]" : "")} />
+                {showBadge && <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-destructive" />}
+              </div>
               <span className={cn("text-xs", isActive ? "font-semibold" : "")}>{item.label}</span>
             </Link>
           );

--- a/src/contexts/notification-context.tsx
+++ b/src/contexts/notification-context.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { collection, onSnapshot, orderBy, query, limit } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+
+interface NotificationContextType {
+  newFeed: boolean;
+  newPlanned: boolean;
+  markFeedSeen: () => void;
+  markPlannedSeen: () => void;
+}
+
+const NotificationContext = createContext<NotificationContextType | undefined>(undefined);
+
+export const NotificationProvider = ({ children }: { children: ReactNode }) => {
+  const [latestFeed, setLatestFeed] = useState<number>(0);
+  const [latestPlanned, setLatestPlanned] = useState<number>(0);
+
+  const [feedLastSeen, setFeedLastSeen] = useState<number>(() => {
+    if (typeof window !== "undefined") {
+      return Number(localStorage.getItem("lastSeenFeed") || "0");
+    }
+    return 0;
+  });
+
+  const [plannedLastSeen, setPlannedLastSeen] = useState<number>(() => {
+    if (typeof window !== "undefined") {
+      return Number(localStorage.getItem("lastSeenPlanned") || "0");
+    }
+    return 0;
+  });
+
+  useEffect(() => {
+    const feedQuery = query(collection(db, "baths"), orderBy("createdAt", "desc"), limit(1));
+    const unsubFeed = onSnapshot(feedQuery, (snap) => {
+      const data = snap.docs[0]?.data();
+      if (data && data.createdAt) {
+        setLatestFeed(data.createdAt);
+      }
+    });
+
+    const plannedQuery = query(collection(db, "baths"), orderBy("createdAt", "desc"), limit(5));
+    const unsubPlanned = onSnapshot(plannedQuery, (snap) => {
+      for (const docSnap of snap.docs) {
+        const data = docSnap.data();
+        if (data.type === "planned" && data.createdAt) {
+          setLatestPlanned(data.createdAt);
+          break;
+        }
+      }
+    });
+
+    return () => {
+      unsubFeed();
+      unsubPlanned();
+    };
+  }, []);
+
+  const markFeedSeen = () => {
+    const now = Date.now();
+    if (typeof window !== "undefined") {
+      localStorage.setItem("lastSeenFeed", String(now));
+    }
+    setFeedLastSeen(now);
+  };
+
+  const markPlannedSeen = () => {
+    const now = Date.now();
+    if (typeof window !== "undefined") {
+      localStorage.setItem("lastSeenPlanned", String(now));
+    }
+    setPlannedLastSeen(now);
+  };
+
+  const newFeed = latestFeed > feedLastSeen;
+  const newPlanned = latestPlanned > plannedLastSeen;
+
+  return (
+    <NotificationContext.Provider value={{ newFeed, newPlanned, markFeedSeen, markPlannedSeen }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+};
+
+export const useNotifications = () => {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) {
+    throw new Error("useNotifications must be used within a NotificationProvider");
+  }
+  return ctx;
+};


### PR DESCRIPTION
## Summary
- add NotificationProvider context for feed/planned content
- mark feed and planned baths as seen when visiting those pages
- display red badge in Navbar when there's unseen content
- wrap layout with NotificationProvider

## Testing
- `npm run lint` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `npm run typecheck`