### PR TITLE
Replace water temperature select with slider

### DIFF
--- a/src/components/app/bath-logging-form.tsx
+++ b/src/components/app/bath-logging-form.tsx
@@ -52,11 +52,24 @@ import { db, storage } from "@/lib/firebase";
 import { addDoc, collection, doc, updateDoc, increment, serverTimestamp } from "firebase/firestore";
 import { ref as storageRef, uploadBytes, getDownloadURL } from "firebase/storage";
 import { useRouter } from "next/navigation";
+import { Slider } from "@/components/ui/slider";
 
 
 const temperatureFeelings: WaterTemperatureFeeling[] = ["kaldt", "Passe", "Digg", "Glovarmt"];
-// Ensure there's a default or placeholder value that is not an empty string for the SelectItem
-const EMPTY_SELECT_VALUE = "_EMPTY_";
+
+const feelingEmojis = ["🥶", "🙂", "😎", "🔥"];
+const feelingRangeClasses = [
+  "bg-blue-500",
+  "bg-sky-500",
+  "bg-orange-500",
+  "bg-red-600",
+];
+const feelingThumbClasses = [
+  "border-blue-500",
+  "border-sky-500",
+  "border-orange-500",
+  "border-red-600",
+];
 
 
 const bathLoggingSchema = z.object({
@@ -374,30 +387,34 @@ export function BathLoggingForm() {
         <FormField
           control={form.control}
           name="waterTemperature"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel className="flex items-center">
-                <Thermometer className="mr-2 h-4 w-4" /> Temperaturfølelse (Valgfritt)
-              </FormLabel>
-              <Select 
-                onValueChange={(value) => field.onChange(value === EMPTY_SELECT_VALUE ? null : value)} 
-                value={field.value ?? EMPTY_SELECT_VALUE}
-              >
+          render={({ field }) => {
+            const currentIndex = field.value ? temperatureFeelings.indexOf(field.value) : 0
+            return (
+              <FormItem>
+                <FormLabel className="flex items-center">
+                  <Thermometer className="mr-2 h-4 w-4" /> Temperaturfølelse (Valgfritt)
+                </FormLabel>
                 <FormControl>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Hvordan føltes vannet?" />
-                  </SelectTrigger>
+                  <div className="flex items-center space-x-3">
+                    <Slider
+                      min={0}
+                      max={3}
+                      step={1}
+                      value={[currentIndex]}
+                      onValueChange={(val) => field.onChange(temperatureFeelings[val[0]])}
+                      trackClassName="bg-muted"
+                      rangeClassName={feelingRangeClasses[currentIndex]}
+                      thumbClassName={feelingThumbClasses[currentIndex]}
+                    />
+                    <span className="text-xl">
+                      {feelingEmojis[currentIndex]}
+                    </span>
+                  </div>
                 </FormControl>
-                <SelectContent>
-                  <SelectItem value={EMPTY_SELECT_VALUE}>Velg følelse (eller la stå)</SelectItem>
-                  {temperatureFeelings.map((feeling) => (
-                     <SelectItem key={feeling} value={feeling}>{feeling.charAt(0).toUpperCase() + feeling.slice(1)}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <FormMessage />
-            </FormItem>
-          )}
+                <FormMessage />
+              </FormItem>
+            )
+          }}
         />
 
         <FormField

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -5,24 +5,48 @@ import * as SliderPrimitive from "@radix-ui/react-slider"
 
 import { cn } from "@/lib/utils"
 
+interface SliderProps
+  extends React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> {
+  trackClassName?: string
+  rangeClassName?: string
+  thumbClassName?: string
+}
+
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center",
-      className
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-))
+  SliderProps
+>(
+  (
+    { className, trackClassName, rangeClassName, thumbClassName, ...props },
+    ref
+  ) => (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        className={cn(
+          "relative h-2 w-full grow overflow-hidden rounded-full bg-secondary",
+          trackClassName
+        )}
+      >
+        <SliderPrimitive.Range
+          className={cn("absolute h-full bg-primary", rangeClassName)}
+        />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        className={cn(
+          "block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+          thumbClassName
+        )}
+      />
+    </SliderPrimitive.Root>
+  )
+)
 Slider.displayName = SliderPrimitive.Root.displayName
 
 export { Slider }


### PR DESCRIPTION
## Summary
- add slider component props for track, range and thumb
- replace water temperature select in bath logging form with slider
- map slider positions to feeling colors and emojis

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Failed to load SWC binary due to fetch failure)*