### PR TITLE
Fix .gitignore to track Firestore configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@ dist/
 
 # Firebase
 .firebase/
-firestore.indexes.json
-firestore.rules
 firebase-debug.log
 firebase-debug.*
 firebase-error.log


### PR DESCRIPTION
## Summary
- keep `firestore.rules` and `firestore.indexes.json` under version control

## Testing
- `npm run lint` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*