### PR TITLE
Prevent sign off when not an attendee

### DIFF
--- a/src/app/profil/[userId]/page.tsx
+++ b/src/app/profil/[userId]/page.tsx
@@ -121,22 +121,36 @@ export default function UserProfilePage() {
   };
 
   const handleSignOffFromPlannedBath = async (bathId: string, bathDescription: string) => {
-     if (!loggedInUser) {
-        toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn." });
-        return;
+    if (!loggedInUser) {
+      toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn." });
+      return;
     }
+
+    // Find the bath locally to check attendance
+    const bath = bathLog.find(
+      (b): b is PlannedBath => b.id === bathId && b.type === "planned"
+    );
+    if (!bath?.attendees?.includes(loggedInUser.uid)) {
+      toast({
+        variant: "destructive",
+        title: "Ikke påmeldt",
+        description: "Du er ikke registrert for dette badet.",
+      });
+      return;
+    }
+
     const bathDocRef = doc(db, "baths", bathId);
-     try {
-        await updateDoc(bathDocRef, {
-            attendees: arrayRemove(loggedInUser.uid)
-        });
-        toast({
-            title: "Avmeldt!",
-            description: `Du er nå avmeldt "${bathDescription}".`,
-        });
+    try {
+      await updateDoc(bathDocRef, {
+        attendees: arrayRemove(loggedInUser.uid),
+      });
+      toast({
+        title: "Avmeldt!",
+        description: `Du er nå avmeldt "${bathDescription}".`,
+      });
     } catch (error) {
-        console.error("Error signing off from bath: ", error);
-        toast({ variant: "destructive", title: "Feil", description: "Kunne ikke melde deg av." });
+      console.error("Error signing off from bath: ", error);
+      toast({ variant: "destructive", title: "Feil", description: "Kunne ikke melde deg av." });
     }
   };
 

--- a/src/components/app/real-time-feed.tsx
+++ b/src/components/app/real-time-feed.tsx
@@ -122,6 +122,18 @@ export function RealTimeFeed() {
       toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn." });
       return;
     }
+    const bath = feedItems.find(
+      (b): b is PlannedBath => b.id === plannedBathId && b.type === "planned"
+    );
+    if (!bath?.attendees?.includes(currentUser.uid)) {
+      toast({
+        variant: "destructive",
+        title: "Ikke påmeldt",
+        description: "Du er ikke registrert for dette badet.",
+      });
+      return;
+    }
+
     const bathDocRef = doc(db, "baths", plannedBathId);
     try {
       await updateDoc(bathDocRef, {

--- a/src/components/app/upcoming-planned-baths.tsx
+++ b/src/components/app/upcoming-planned-baths.tsx
@@ -106,6 +106,16 @@ export function UpcomingPlannedBaths() {
       toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn." });
       return;
     }
+    const bath = baths.find(b => b.id === bathId);
+    if (!bath?.attendees?.includes(currentUser.uid)) {
+      toast({
+        variant: "destructive",
+        title: "Ikke påmeldt",
+        description: "Du er ikke registrert for dette badet.",
+      });
+      return;
+    }
+
     const bathRef = doc(db, "baths", bathId);
     try {
       await updateDoc(bathRef, {


### PR DESCRIPTION
## Summary
- avoid confusing Firestore errors by checking that the current user is in `attendees` before removing them
- show a toast if the user wasn't registered for the bath

## Testing
- `npm run lint` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `npm run typecheck`