### PR TITLE
Prevent duplicate sign-ups for planned baths

### DIFF
--- a/src/app/profil/[userId]/page.tsx
+++ b/src/app/profil/[userId]/page.tsx
@@ -102,6 +102,16 @@ export default function UserProfilePage() {
         toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn for å melde deg på." });
         return;
     }
+    const bath = bathLog.find(
+      (b): b is PlannedBath => b.id === bathId && b.type === "planned"
+    );
+    if (bath?.attendees?.includes(loggedInUser.uid)) {
+        toast({
+            title: "Allerede påmeldt",
+            description: "Du er allerede påmeldt",
+        });
+        return;
+    }
     const bathDocRef = doc(db, "baths", bathId);
     try {
         await updateDoc(bathDocRef, {

--- a/src/components/app/real-time-feed.tsx
+++ b/src/components/app/real-time-feed.tsx
@@ -99,6 +99,16 @@ export function RealTimeFeed() {
       toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn for å melde deg på." });
       return;
     }
+    const bath = feedItems.find(
+      (b): b is PlannedBath => b.id === plannedBathId && b.type === "planned"
+    );
+    if (bath?.attendees?.includes(currentUser.uid)) {
+      toast({
+        title: "Allerede påmeldt",
+        description: "Du er allerede påmeldt",
+      });
+      return;
+    }
     const bathDocRef = doc(db, "baths", plannedBathId);
     try {
       await updateDoc(bathDocRef, {

--- a/src/components/app/upcoming-planned-baths.tsx
+++ b/src/components/app/upcoming-planned-baths.tsx
@@ -91,6 +91,14 @@ export function UpcomingPlannedBaths() {
       toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn for å melde deg på." });
       return;
     }
+    const bath = baths.find(b => b.id === bathId);
+    if (bath?.attendees?.includes(currentUser.uid)) {
+      toast({
+        title: "Allerede påmeldt",
+        description: "Du er allerede påmeldt",
+      });
+      return;
+    }
     const bathRef = doc(db, "baths", bathId);
     try {
       await updateDoc(bathRef, {


### PR DESCRIPTION
## Summary
- avoid duplicate sign-ups in `UpcomingPlannedBaths`
- do the same duplicate check in `RealTimeFeed`
- check existing attendees before sign-up on profile page

## Testing
- `npm run lint` *(fails: fetch failed)*
- `npm run typecheck`
- `npm test` *(fails: missing script)*