### PR TITLE
Fix planned bath attendance

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -45,7 +45,7 @@ service cloud.firestore {
         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['reactions', 'commentCount']) ||
         // Tillat oppdatering av KUN 'attendees' HVIS brukeren legger til/fjerner seg selv
         (
-          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['attendees']) &&
+          request.writeFields.hasOnly(['attendees']) &&
           isUpdatingSelfInAttendees()
         )
       );

--- a/src/app/profil/[userId]/page.tsx
+++ b/src/app/profil/[userId]/page.tsx
@@ -13,7 +13,8 @@ import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth, type UserProfile } from "@/contexts/auth-context";
 import { db } from "@/lib/firebase";
-import { doc, getDoc, getDocs, collection, query, where, orderBy, onSnapshot, updateDoc, arrayUnion, arrayRemove, Timestamp, documentId } from "firebase/firestore";
+import { doc, getDoc, getDocs, collection, query, where, orderBy, onSnapshot, Timestamp, documentId } from "firebase/firestore";
+import { joinBath, leaveBath } from "@/services/bath-attendance";
 import { format as formatDateFns } from "date-fns";
 import { nb } from "date-fns/locale";
 import Link from "next/link";
@@ -112,11 +113,8 @@ export default function UserProfilePage() {
         });
         return;
     }
-    const bathDocRef = doc(db, "baths", bathId);
     try {
-        await updateDoc(bathDocRef, {
-            attendees: arrayUnion(loggedInUser.uid)
-        });
+        await joinBath(bathId, loggedInUser.uid);
         // Optimistically update local state for attendees if needed, or rely on snapshot listener
         setAttendeesDetails(prev => ({
             ...prev,
@@ -151,11 +149,8 @@ export default function UserProfilePage() {
       return;
     }
 
-    const bathDocRef = doc(db, "baths", bathId);
     try {
-      await updateDoc(bathDocRef, {
-        attendees: arrayRemove(loggedInUser.uid),
-      });
+      await leaveBath(bathId, loggedInUser.uid);
       toast({
         title: "Avmeldt!",
         description: `Du er nå avmeldt "${bathDescription}".`,

--- a/src/components/app/real-time-feed.tsx
+++ b/src/components/app/real-time-feed.tsx
@@ -16,7 +16,8 @@ import { useToast } from "@/hooks/use-toast";
 import { useAuth, type UserProfile } from "@/contexts/auth-context";
 import { db } from "@/lib/firebase";
 import { useNotifications } from "@/contexts/notification-context";
-import { collection, query, orderBy, onSnapshot, doc, updateDoc, arrayUnion, arrayRemove, getDoc, Timestamp, increment } from "firebase/firestore";
+import { collection, query, orderBy, onSnapshot, doc, updateDoc, getDoc, Timestamp, increment } from "firebase/firestore";
+import { joinBath, leaveBath } from "@/services/bath-attendance";
 
 import { CommentsDialog } from "./comments-dialog";
 import { format } from "date-fns";
@@ -109,11 +110,8 @@ export function RealTimeFeed() {
       });
       return;
     }
-    const bathDocRef = doc(db, "baths", plannedBathId);
     try {
-      await updateDoc(bathDocRef, {
-        attendees: arrayUnion(currentUser.uid)
-      });
+      await joinBath(plannedBathId, currentUser.uid);
       // Optimistically update local state (attendeesDetails will eventually catch up via snapshot)
       // No need to directly setAttendeesDetails here as the onSnapshot listener will handle it
       toast({
@@ -144,11 +142,8 @@ export function RealTimeFeed() {
       return;
     }
 
-    const bathDocRef = doc(db, "baths", plannedBathId);
     try {
-      await updateDoc(bathDocRef, {
-        attendees: arrayRemove(currentUser.uid)
-      });
+      await leaveBath(plannedBathId, currentUser.uid);
       toast({
         title: "Avmeldt!",
         description: `Du er nå avmeldt "${bathDescription}".`,

--- a/src/components/app/upcoming-planned-baths.tsx
+++ b/src/components/app/upcoming-planned-baths.tsx
@@ -13,7 +13,8 @@ import { useAuth, type UserProfile } from "@/contexts/auth-context";
 import { useToast } from "@/hooks/use-toast";
 import { db } from "@/lib/firebase";
 import { useNotifications } from "@/contexts/notification-context";
-import { collection, query, orderBy, onSnapshot, doc, updateDoc, arrayUnion, arrayRemove, getDocs, where, documentId } from "firebase/firestore";
+import { collection, query, orderBy, onSnapshot, getDocs, where, documentId } from "firebase/firestore";
+import { joinBath, leaveBath } from "@/services/bath-attendance";
 import type { BathEntry, PlannedBath } from "@/types/bath";
 import { format } from "date-fns";
 import { nb } from "date-fns/locale";
@@ -99,11 +100,8 @@ export function UpcomingPlannedBaths() {
       });
       return;
     }
-    const bathRef = doc(db, "baths", bathId);
     try {
-      await updateDoc(bathRef, {
-        attendees: arrayUnion(currentUser.uid)
-      });
+      await joinBath(bathId, currentUser.uid);
       toast({ title: "Påmeldt!", description: `Du er nå påmeldt \"${description}\".` });
     } catch (error) {
       console.error("Error signing up: ", error);
@@ -126,11 +124,8 @@ export function UpcomingPlannedBaths() {
       return;
     }
 
-    const bathRef = doc(db, "baths", bathId);
     try {
-      await updateDoc(bathRef, {
-        attendees: arrayRemove(currentUser.uid)
-      });
+      await leaveBath(bathId, currentUser.uid);
       toast({ title: "Avmeldt!", description: `Du er nå avmeldt \"${description}\".` });
     } catch (error) {
       console.error("Error signing off: ", error);

--- a/src/services/bath-attendance.ts
+++ b/src/services/bath-attendance.ts
@@ -1,0 +1,48 @@
+// Helper functions to join and leave planned baths using Firestore transactions
+import { db } from '@/lib/firebase';
+import { doc, runTransaction } from 'firebase/firestore';
+
+/**
+ * Adds the current user's uid to the attendees array of a bath document.
+ * Ensures only the user's uid is added and no other field is modified.
+ *
+ * @param bathId The id of the bath document
+ * @param uid The uid of the user attending
+ */
+export async function joinBath(bathId: string, uid: string): Promise<void> {
+  const bathRef = doc(db, 'baths', bathId);
+  await runTransaction(db, async (tx) => {
+    const snap = await tx.get(bathRef);
+    if (!snap.exists()) {
+      throw new Error('Bath does not exist');
+    }
+    const data = snap.data();
+    const current: string[] = (data.attendees ?? []) as string[];
+    if (current.includes(uid)) {
+      return;
+    }
+    tx.update(bathRef, { attendees: [...current, uid] });
+  });
+}
+
+/**
+ * Removes the current user's uid from the attendees array of a bath document.
+ *
+ * @param bathId The id of the bath document
+ * @param uid The uid of the user to remove
+ */
+export async function leaveBath(bathId: string, uid: string): Promise<void> {
+  const bathRef = doc(db, 'baths', bathId);
+  await runTransaction(db, async (tx) => {
+    const snap = await tx.get(bathRef);
+    if (!snap.exists()) {
+      throw new Error('Bath does not exist');
+    }
+    const data = snap.data();
+    const current: string[] = (data.attendees ?? []) as string[];
+    if (!current.includes(uid)) {
+      return;
+    }
+    tx.update(bathRef, { attendees: current.filter((id) => id !== uid) });
+  });
+}


### PR DESCRIPTION
## Summary
- add transactional helpers to join and leave baths
- use helpers in upcoming planned baths listing
- use helpers in real-time feed
- use helpers in user profile page
- allow attendee updates via transactional writes in `firestore.rules`

## Testing
- `npm run lint` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `npm run typecheck`
