### PR TITLE
Fix attendee update logic

### DIFF
--- a/src/services/bath-attendance.ts
+++ b/src/services/bath-attendance.ts
@@ -1,6 +1,6 @@
 // Helper functions to join and leave planned baths using Firestore transactions
 import { db } from '@/lib/firebase';
-import { doc, runTransaction } from 'firebase/firestore';
+import { doc, runTransaction, arrayUnion, arrayRemove } from 'firebase/firestore';
 
 /**
  * Adds the current user's uid to the attendees array of a bath document.
@@ -21,7 +21,8 @@ export async function joinBath(bathId: string, uid: string): Promise<void> {
     if (current.includes(uid)) {
       return;
     }
-    tx.update(bathRef, { attendees: [...current, uid] });
+    // Use arrayUnion to avoid overwriting other fields and ensure atomic add
+    tx.update(bathRef, { attendees: arrayUnion(uid) });
   });
 }
 
@@ -43,6 +44,7 @@ export async function leaveBath(bathId: string, uid: string): Promise<void> {
     if (!current.includes(uid)) {
       return;
     }
-    tx.update(bathRef, { attendees: current.filter((id) => id !== uid) });
+    // Use arrayRemove to atomically remove the user without touching other fields
+    tx.update(bathRef, { attendees: arrayRemove(uid) });
   });
 }


### PR DESCRIPTION
## Summary
- use `arrayUnion` and `arrayRemove` when adding/removing bath attendees

## Testing
- `npm run lint` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*