### PR TITLE
Store attendee names in baths

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,8 +3,8 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // Helper function to check 'attendees' update logic
-    function isUpdatingSelfInAttendees() {
+    // Helper function to ensure only one attendee name is added or removed
+    function isUpdatingAttendees() {
       // Definer variabler med 'let' øverst i funksjonen.
       let attendeesExists = 'attendees' in request.resource.data;
       let nextAttendees = request.resource.data.get('attendees', null); // Bruk .get for sikkerhet
@@ -15,10 +15,10 @@ service cloud.firestore {
       // Hvis ikke, bruk en tom diff ([].diff([])) for å unngå feil.
       let diff = isList ? nextAttendees.diff(currentAttendees) : [].diff([]);
 
-      // Returner true KUN hvis det ER en liste OG diff-en matcher betingelsene.
+      // Return true if exactly one name is added or removed
       return isList && (
-        (diff.added().size() == 1 && diff.added()[0] == request.auth.uid && diff.removed().size() == 0) ||
-        (diff.removed().size() == 1 && diff.removed()[0] == request.auth.uid && diff.added().size() == 0)
+        (diff.added().size() == 1 && diff.removed().size() == 0) ||
+        (diff.removed().size() == 1 && diff.added().size() == 0)
       );
     }
 
@@ -43,11 +43,11 @@ service cloud.firestore {
         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['commentCount']) ||
         // Tillat oppdatering av KUN 'reactions' og 'commentCount'
         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['reactions', 'commentCount']) ||
-        // Tillat oppdatering av KUN 'attendees' HVIS brukeren legger til/fjerner seg selv
+        // Allow updating only 'attendees' with one name added or removed
         (
           (request.resource.data.diff(resource.data).affectedKeys().hasOnly(['attendees']) ||
           (request.resource.data.diff(resource.data).affectedKeys().size() == 0 && 'attendees' in request.resource.data)) &&
-          isUpdatingSelfInAttendees()
+          isUpdatingAttendees()
         )
       );
 

--- a/src/app/profil/[userId]/page.tsx
+++ b/src/app/profil/[userId]/page.tsx
@@ -13,7 +13,7 @@ import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth, type UserProfile } from "@/contexts/auth-context";
 import { db } from "@/lib/firebase";
-import { doc, getDoc, getDocs, collection, query, where, orderBy, onSnapshot, Timestamp, documentId } from "firebase/firestore";
+import { doc, getDoc, collection, query, where, orderBy, onSnapshot, Timestamp } from "firebase/firestore";
 import { joinBath, leaveBath } from "@/services/bath-attendance";
 import { format as formatDateFns } from "date-fns";
 import { nb } from "date-fns/locale";
@@ -29,7 +29,6 @@ export default function UserProfilePage() {
 
   const [user, setUser] = useState<UserProfile | null>(null);
   const [bathLog, setBathLog] = useState<BathEntry[]>([]);
-  const [attendeesDetails, setAttendeesDetails] = useState<Record<string, Pick<UserProfile, 'name' | 'avatarUrl'>>>({});
   const [profileLoading, setProfileLoading] = useState(true);
   const [logLoading, setLogLoading] = useState(true);
 
@@ -57,36 +56,14 @@ export default function UserProfilePage() {
       const bathsCollectionRef = collection(db, "baths");
       const q = query(bathsCollectionRef, where("userId", "==", userId), orderBy("createdAt", "desc"));
       
-      const unsubscribe = onSnapshot(q, async (snapshot) => {
+      const unsubscribe = onSnapshot(q, (snapshot) => {
         const logEntries: BathEntry[] = [];
-        const attendeeIdsToFetch = new Set<string>();
 
         snapshot.forEach(doc => {
           const data = doc.data() as BathEntry;
           logEntries.push({ ...data, id: doc.id });
-           if (data.type === 'planned') {
-            data.attendees?.forEach(uid => attendeeIdsToFetch.add(uid));
-          }
         });
         setBathLog(logEntries);
-
-        // Fetch details for attendees
-        if (attendeeIdsToFetch.size > 0) {
-            const idsToQuery = Array.from(attendeeIdsToFetch).filter(uid => !attendeesDetails[uid]);
-            const newAttendeesDetails: Record<string, Pick<UserProfile, 'name' | 'avatarUrl'>> = {};
-            for (let i = 0; i < idsToQuery.length; i += 10) {
-                const chunk = idsToQuery.slice(i, i + 10);
-                const usersQ = query(collection(db, "users"), where(documentId(), "in", chunk));
-                const usersSnap = await getDocs(usersQ);
-                usersSnap.forEach(userSnap => {
-                    const userData = userSnap.data() as UserProfile;
-                    newAttendeesDetails[userSnap.id] = { name: userData.name, avatarUrl: userData.avatarUrl };
-                });
-            }
-            if (Object.keys(newAttendeesDetails).length > 0) {
-                setAttendeesDetails(prev => ({ ...prev, ...newAttendeesDetails }));
-            }
-        }
         setLogLoading(false);
       }, (error) => {
         console.error("Error fetching bath log:", error);
@@ -106,7 +83,7 @@ export default function UserProfilePage() {
     const bath = bathLog.find(
       (b): b is PlannedBath => b.id === bathId && b.type === "planned"
     );
-    if (bath?.attendees?.includes(loggedInUser.uid)) {
+    if (loggedInUserProfile && bath?.attendees?.includes(loggedInUserProfile.name)) {
         toast({
             title: "Allerede påmeldt",
             description: "Du er allerede påmeldt",
@@ -114,12 +91,11 @@ export default function UserProfilePage() {
         return;
     }
     try {
-        await joinBath(bathId, loggedInUser.uid);
-        // Optimistically update local state for attendees if needed, or rely on snapshot listener
-        setAttendeesDetails(prev => ({
-            ...prev,
-            [loggedInUser.uid]: { name: loggedInUserProfile?.name || "Deg", avatarUrl: loggedInUserProfile?.avatarUrl }
-        }));
+        if (!loggedInUserProfile) {
+            toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn." });
+            return;
+        }
+        await joinBath(bathId, loggedInUserProfile.name);
         toast({
             title: "Påmeldt!",
             description: `Du er nå påmeldt "${bathDescription}".`,
@@ -131,7 +107,7 @@ export default function UserProfilePage() {
   };
 
   const handleSignOffFromPlannedBath = async (bathId: string, bathDescription: string) => {
-    if (!loggedInUser) {
+    if (!loggedInUser || !loggedInUserProfile) {
       toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn." });
       return;
     }
@@ -140,7 +116,7 @@ export default function UserProfilePage() {
     const bath = bathLog.find(
       (b): b is PlannedBath => b.id === bathId && b.type === "planned"
     );
-    if (!bath?.attendees?.includes(loggedInUser.uid)) {
+    if (!bath?.attendees?.includes(loggedInUserProfile.name)) {
       toast({
         variant: "destructive",
         title: "Ikke påmeldt",
@@ -150,7 +126,7 @@ export default function UserProfilePage() {
     }
 
     try {
-      await leaveBath(bathId, loggedInUser.uid);
+      await leaveBath(bathId, loggedInUserProfile.name);
       toast({
         title: "Avmeldt!",
         description: `Du er nå avmeldt "${bathDescription}".`,
@@ -281,13 +257,13 @@ export default function UserProfilePage() {
                           <Users className="h-4 w-4 mr-2 text-muted-foreground" />
                           <span>{bath.attendees ? bath.attendees.length : 0} påmeldt.</span>
                         </div>
-                        {bath.attendees && bath.attendees.length > 0 && <p className="text-muted-foreground">Deltakere: {bath.attendees.map(uid => attendeesDetails[uid]?.name || '...').join(', ')}</p>}
+                        {bath.attendees && bath.attendees.length > 0 && <p className="text-muted-foreground">Deltakere: {bath.attendees.join(', ')}</p>}
 
                         {loggedInUser && loggedInUser.uid === bath.userId ? (
                            <Button size="sm" variant="outline" className="mt-2 w-full sm:w-auto" disabled>
                              <Info className="mr-2 h-4 w-4" /> Du arrangerer
                            </Button>
-                        ) : loggedInUser && bath.attendees && bath.attendees.includes(loggedInUser.uid) ? (
+                        ) : loggedInUser && loggedInUserProfile && bath.attendees && bath.attendees.includes(loggedInUserProfile.name) ? (
                            <Button 
                              size="sm" 
                              variant="outline" 

--- a/src/components/app/real-time-feed.tsx
+++ b/src/components/app/real-time-feed.tsx
@@ -13,10 +13,10 @@ import type { FC } from "react";
 import { useState, useEffect } from "react";
 import type { BathEntry, PlannedBath } from "@/types/bath"; 
 import { useToast } from "@/hooks/use-toast";
-import { useAuth, type UserProfile } from "@/contexts/auth-context";
+import { useAuth } from "@/contexts/auth-context";
 import { db } from "@/lib/firebase";
 import { useNotifications } from "@/contexts/notification-context";
-import { collection, query, orderBy, onSnapshot, doc, updateDoc, getDoc, Timestamp, increment } from "firebase/firestore";
+import { collection, query, orderBy, onSnapshot, doc, updateDoc, Timestamp, increment } from "firebase/firestore";
 import { joinBath, leaveBath } from "@/services/bath-attendance";
 
 import { CommentsDialog } from "./comments-dialog";
@@ -32,16 +32,12 @@ const ReactionButton: FC<{ icon: React.ElementType, count: number, label: string
   </Button>
 );
 
-interface AttendeeDetails {
-  [uid: string]: Pick<UserProfile, 'name' | 'avatarUrl'>;
-}
 
 export function RealTimeFeed() {
   const { toast } = useToast();
   const { currentUser, userProfile, loading: authLoading } = useAuth();
   const { markFeedSeen } = useNotifications();
   const [feedItems, setFeedItems] = useState<BathEntry[]>([]);
-  const [attendeesDetails, setAttendeesDetails] = useState<AttendeeDetails>({});
   const [feedLoading, setFeedLoading] = useState(true);
   const [openCommentsId, setOpenCommentsId] = useState<string | null>(null);
 
@@ -50,35 +46,13 @@ export function RealTimeFeed() {
     const bathsCollectionRef = collection(db, "baths");
     const q = query(bathsCollectionRef, orderBy("createdAt", "desc"));
 
-    const unsubscribe = onSnapshot(q, async (querySnapshot) => {
+    const unsubscribe = onSnapshot(q, (querySnapshot) => {
       const items: BathEntry[] = [];
-      const attendeeIdsToFetch = new Set<string>();
-
       querySnapshot.forEach((doc) => {
         const data = doc.data() as BathEntry;
         items.push({ ...data, id: doc.id });
-        if (data.type === 'planned') {
-            data.attendees?.forEach(uid => attendeeIdsToFetch.add(uid));
-        }
       });
-
       setFeedItems(items);
-      
-      // Fetch details for attendees if there are any new ones
-      if (attendeeIdsToFetch.size > 0) {
-        const newAttendeesDetails: AttendeeDetails = {};
-        for (const uid of Array.from(attendeeIdsToFetch)) {
-            if (!attendeesDetails[uid]) { // Only fetch if not already fetched
-                const userDocRef = doc(db, "users", uid);
-                const userSnap = await getDoc(userDocRef);
-                if (userSnap.exists()) {
-                    const userData = userSnap.data() as UserProfile;
-                    newAttendeesDetails[uid] = { name: userData.name, avatarUrl: userData.avatarUrl };
-                }
-            }
-        }
-        setAttendeesDetails(prev => ({ ...prev, ...newAttendeesDetails }));
-      }
       setFeedLoading(false);
     }, (error) => {
       console.error("Error fetching feed items: ", error);
@@ -87,7 +61,7 @@ export function RealTimeFeed() {
     });
 
     return () => unsubscribe();
-  }, [toast]); // Removed attendeesDetails from dependency array to prevent potential infinite loop
+  }, [toast]);
 
   useEffect(() => {
     if (!feedLoading) {
@@ -103,17 +77,19 @@ export function RealTimeFeed() {
     const bath = feedItems.find(
       (b): b is PlannedBath => b.id === plannedBathId && b.type === "planned"
     );
-    if (bath?.attendees?.includes(currentUser.uid)) {
+    if (userProfile && bath?.attendees?.includes(userProfile.name)) {
       toast({
         title: "Allerede påmeldt",
         description: "Du er allerede påmeldt",
       });
       return;
     }
+    if (!userProfile) {
+      toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn." });
+      return;
+    }
     try {
-      await joinBath(plannedBathId, currentUser.uid);
-      // Optimistically update local state (attendeesDetails will eventually catch up via snapshot)
-      // No need to directly setAttendeesDetails here as the onSnapshot listener will handle it
+      await joinBath(plannedBathId, userProfile.name);
       toast({
         title: "Påmeldt!",
         description: `Du er nå påmeldt "${bathDescription}".`,
@@ -126,14 +102,14 @@ export function RealTimeFeed() {
   };
 
   const handleSignOff = async (plannedBathId: string, bathDescription: string) => {
-    if (!currentUser) {
+    if (!currentUser || !userProfile) {
       toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn." });
       return;
     }
     const bath = feedItems.find(
       (b): b is PlannedBath => b.id === plannedBathId && b.type === "planned"
     );
-    if (!bath?.attendees?.includes(currentUser.uid)) {
+    if (!bath?.attendees?.includes(userProfile.name)) {
       toast({
         variant: "destructive",
         title: "Ikke påmeldt",
@@ -143,7 +119,7 @@ export function RealTimeFeed() {
     }
 
     try {
-      await leaveBath(plannedBathId, currentUser.uid);
+      await leaveBath(plannedBathId, userProfile.name);
       toast({
         title: "Avmeldt!",
         description: `Du er nå avmeldt "${bathDescription}".`,
@@ -279,7 +255,7 @@ export function RealTimeFeed() {
                 <p className="text-sm text-muted-foreground">Antall påmeldte: {entry.attendees ? entry.attendees.length : 0}</p>
                 {entry.attendees && entry.attendees.length > 0 && (
                   <p className="text-sm text-muted-foreground">
-                    Deltakere: {entry.attendees.map(uid => attendeesDetails[uid]?.name || 'Laster...').join(', ')}
+                    Deltakere: {entry.attendees.join(', ')}
                   </p>
                 )}
               </div>
@@ -337,7 +313,7 @@ export function RealTimeFeed() {
                    <Button size="sm" variant="outline" disabled>
                      <Info className="h-4 w-4 mr-2" /> Du arrangerer
                    </Button>
-                ) : currentUser && entry.attendees && entry.attendees.includes(currentUser.uid) ? (
+                ) : currentUser && userProfile && entry.attendees && entry.attendees.includes(userProfile.name) ? (
                   <Button
                     size="sm"
                     variant="outline"

--- a/src/components/app/upcoming-planned-baths.tsx
+++ b/src/components/app/upcoming-planned-baths.tsx
@@ -9,36 +9,30 @@ import { CalendarCheck, Users, UserMinus, UserPlus, Info, Waves } from "lucide-r
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { useAuth, type UserProfile } from "@/contexts/auth-context";
+import { useAuth } from "@/contexts/auth-context";
 import { useToast } from "@/hooks/use-toast";
 import { db } from "@/lib/firebase";
 import { useNotifications } from "@/contexts/notification-context";
-import { collection, query, orderBy, onSnapshot, getDocs, where, documentId } from "firebase/firestore";
+import { collection, query, orderBy, onSnapshot } from "firebase/firestore";
 import { joinBath, leaveBath } from "@/services/bath-attendance";
 import type { BathEntry, PlannedBath } from "@/types/bath";
 import { format } from "date-fns";
 import { nb } from "date-fns/locale";
 import { Timestamp } from "firebase/firestore";
 
-interface AttendeeDetails {
-  [uid: string]: Pick<UserProfile, "name" | "avatarUrl">;
-}
-
 export function UpcomingPlannedBaths() {
   const { toast } = useToast();
   const { currentUser, loading: authLoading } = useAuth();
   const { markPlannedSeen } = useNotifications();
   const [baths, setBaths] = useState<PlannedBath[]>([]);
-  const [attendeesDetails, setAttendeesDetails] = useState<AttendeeDetails>({});
   const [loadingBaths, setLoadingBaths] = useState(true);
 
   useEffect(() => {
     setLoadingBaths(true);
     const bathsRef = collection(db, "baths");
     const q = query(bathsRef, orderBy("createdAt", "desc"));
-    const unsubscribe = onSnapshot(q, async (snapshot) => {
+    const unsubscribe = onSnapshot(q, (snapshot) => {
       const planned: PlannedBath[] = [];
-      const attendeeIdsToFetch = new Set<string>();
 
       snapshot.forEach((docSnap) => {
         const data = docSnap.data() as BathEntry;
@@ -47,30 +41,12 @@ export function UpcomingPlannedBaths() {
           const bathDateTime = new Date(`${bath.date}T${bath.time}`);
           if (bathDateTime >= new Date()) {
             planned.push(bath);
-            bath.attendees?.forEach((uid) => attendeeIdsToFetch.add(uid));
           }
         }
       });
 
       planned.sort((a, b) => new Date(`${a.date}T${a.time}`).getTime() - new Date(`${b.date}T${b.time}`).getTime());
       setBaths(planned);
-
-      if (attendeeIdsToFetch.size > 0) {
-        const idsToQuery = Array.from(attendeeIdsToFetch).filter((uid) => !attendeesDetails[uid]);
-        const newDetails: AttendeeDetails = {};
-        for (let i = 0; i < idsToQuery.length; i += 10) {
-          const chunk = idsToQuery.slice(i, i + 10);
-          const userQuery = query(collection(db, "users"), where(documentId(), "in", chunk));
-          const usersSnap = await getDocs(userQuery);
-          usersSnap.forEach((userSnap) => {
-            const userData = userSnap.data() as UserProfile;
-            newDetails[userSnap.id] = { name: userData.name, avatarUrl: userData.avatarUrl };
-          });
-        }
-        if (Object.keys(newDetails).length > 0) {
-          setAttendeesDetails((prev) => ({ ...prev, ...newDetails }));
-        }
-      }
       setLoadingBaths(false);
     }, (error) => {
       console.error("Error fetching planned baths: ", error);
@@ -88,12 +64,12 @@ export function UpcomingPlannedBaths() {
   }, [loadingBaths, markPlannedSeen, baths]);
 
   const handleSignUp = async (bathId: string, description: string) => {
-    if (!currentUser) {
+    if (!currentUser || !currentUser.displayName) {
       toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn for å melde deg på." });
       return;
     }
     const bath = baths.find(b => b.id === bathId);
-    if (bath?.attendees?.includes(currentUser.uid)) {
+    if (bath?.attendees?.includes(currentUser.displayName)) {
       toast({
         title: "Allerede påmeldt",
         description: "Du er allerede påmeldt",
@@ -101,7 +77,7 @@ export function UpcomingPlannedBaths() {
       return;
     }
     try {
-      await joinBath(bathId, currentUser.uid);
+      await joinBath(bathId, currentUser.displayName);
       toast({ title: "Påmeldt!", description: `Du er nå påmeldt \"${description}\".` });
     } catch (error) {
       console.error("Error signing up: ", error);
@@ -110,12 +86,12 @@ export function UpcomingPlannedBaths() {
   };
 
   const handleSignOff = async (bathId: string, description: string) => {
-    if (!currentUser) {
+    if (!currentUser || !currentUser.displayName) {
       toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn." });
       return;
     }
     const bath = baths.find(b => b.id === bathId);
-    if (!bath?.attendees?.includes(currentUser.uid)) {
+    if (!bath?.attendees?.includes(currentUser.displayName)) {
       toast({
         variant: "destructive",
         title: "Ikke påmeldt",
@@ -125,7 +101,7 @@ export function UpcomingPlannedBaths() {
     }
 
     try {
-      await leaveBath(bathId, currentUser.uid);
+      await leaveBath(bathId, currentUser.displayName);
       toast({ title: "Avmeldt!", description: `Du er nå avmeldt \"${description}\".` });
     } catch (error) {
       console.error("Error signing off: ", error);
@@ -194,7 +170,7 @@ export function UpcomingPlannedBaths() {
             <p className="text-sm text-muted-foreground">{formatDateForDisplay(bath.date)} kl. {bath.time}</p>
             <p className="text-sm text-muted-foreground">Antall påmeldte: {bath.attendees ? bath.attendees.length : 0}</p>
             {bath.attendees && bath.attendees.length > 0 && (
-              <p className="text-sm text-muted-foreground">Deltakere: {bath.attendees.map(uid => attendeesDetails[uid]?.name || 'Laster...').join(', ')}</p>
+              <p className="text-sm text-muted-foreground">Deltakere: {bath.attendees.join(', ')}</p>
             )}
           </CardContent>
           <Separator />
@@ -207,7 +183,7 @@ export function UpcomingPlannedBaths() {
               <Button size="sm" variant="outline" disabled>
                 <Info className="h-4 w-4 mr-2" /> Du arrangerer
               </Button>
-            ) : currentUser && bath.attendees && bath.attendees.includes(currentUser.uid) ? (
+            ) : currentUser && bath.attendees && currentUser.displayName && bath.attendees.includes(currentUser.displayName) ? (
               <Button size="sm" variant="outline" onClick={() => handleSignOff(bath.id, bath.description)}>
                 <UserMinus className="h-4 w-4 mr-2" /> Meld deg av
               </Button>

--- a/src/services/bath-attendance.ts
+++ b/src/services/bath-attendance.ts
@@ -1,16 +1,16 @@
 // Helper functions to join and leave planned baths using Firestore transactions
-import { db, auth } from '@/lib/firebase';
+import { db } from '@/lib/firebase';
 import { doc, runTransaction } from 'firebase/firestore';
 
 /**
- * Adds the current user's uid to the attendees array of a bath document.
- * Ensures only the user's uid is added and no other field is modified.
+ * Adds the given user name to the attendees array of a bath document.
+ * Ensures only the name is added and no other field is modified.
  *
  * @param bathId The id of the bath document
- * @param uid The uid of the user attending
+ * @param name The name of the user attending
  */
-export async function joinBath(bathId: string, uid: string): Promise<void> {
-  if (!auth.currentUser || auth.currentUser.uid !== uid) {
+export async function joinBath(bathId: string, name: string): Promise<void> {
+  if (!name) {
     throw new Error('User must be logged in');
   }
   const bathRef = doc(db, 'baths', bathId);
@@ -21,22 +21,21 @@ export async function joinBath(bathId: string, uid: string): Promise<void> {
     }
     const data = snap.data();
     const current: string[] = (data.attendees ?? []) as string[];
-    if (current.includes(uid)) {
+    if (current.includes(name)) {
       return;
     }
-    // Update attendees array directly to satisfy security rules
-    tx.update(bathRef, { attendees: [...current, uid] });
+    tx.update(bathRef, { attendees: [...current, name] });
   });
 }
 
 /**
- * Removes the current user's uid from the attendees array of a bath document.
+ * Removes the given user name from the attendees array of a bath document.
  *
  * @param bathId The id of the bath document
- * @param uid The uid of the user to remove
+ * @param name The name of the user to remove
  */
-export async function leaveBath(bathId: string, uid: string): Promise<void> {
-  if (!auth.currentUser || auth.currentUser.uid !== uid) {
+export async function leaveBath(bathId: string, name: string): Promise<void> {
+  if (!name) {
     throw new Error('User must be logged in');
   }
   const bathRef = doc(db, 'baths', bathId);
@@ -47,11 +46,10 @@ export async function leaveBath(bathId: string, uid: string): Promise<void> {
     }
     const data = snap.data();
     const current: string[] = (data.attendees ?? []) as string[];
-    if (!current.includes(uid)) {
+    if (!current.includes(name)) {
       return;
     }
-    // Update attendees array directly to satisfy security rules
-    tx.update(bathRef, { attendees: current.filter((id) => id !== uid) });
+    tx.update(bathRef, { attendees: current.filter((n) => n !== name) });
   });
 }
 

--- a/src/types/bath.ts
+++ b/src/types/bath.ts
@@ -33,7 +33,7 @@ export interface LoggedBath extends BathBase {
 export interface PlannedBath extends BathBase {
   type: 'planned';
   description: string; // Title or description of the planned event
-  attendees: string[]; // Array of user UIDs who are attending
+  attendees: string[]; // Names of attendees
   // invitedGuestsText is part of the form, not necessarily stored directly this way unless needed.
   // It's more of a note during creation.
 }


### PR DESCRIPTION
## Notes
- `npm run lint` failed to download the SWC binary due to missing network access
- `npm run typecheck` succeeded

## Summary
- save attendee names rather than UIDs
- simplify Firestore rules for attendee updates
- update components to check and display names
