### PR TITLE
Add signups to feed page

### DIFF
--- a/src/components/app/real-time-feed.tsx
+++ b/src/components/app/real-time-feed.tsx
@@ -11,13 +11,18 @@ import Link from "next/link";
 import { Separator } from "@/components/ui/separator";
 import type { FC } from "react";
 import { useState, useEffect } from "react";
-import type { BathEntry, PlannedBath } from "@/types/bath"; 
+import type { BathEntry } from "@/types/bath";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/contexts/auth-context";
 import { db } from "@/lib/firebase";
 import { useNotifications } from "@/contexts/notification-context";
 import { collection, query, orderBy, onSnapshot, doc, updateDoc, Timestamp, increment } from "firebase/firestore";
-import { joinBath, leaveBath } from "@/services/bath-attendance";
+import {
+  signUpForBath,
+  cancelSignUp,
+  getBathSignups,
+} from "@/services/bath-signup";
+import type { BathSignup } from "@/types/signup";
 
 import { CommentsDialog } from "./comments-dialog";
 import { format } from "date-fns";
@@ -34,64 +39,97 @@ const ReactionButton: FC<{ icon: React.ElementType, count: number, label: string
 
 export function RealTimeFeed() {
   const { toast } = useToast();
-  const { currentUser, userProfile, loading: authLoading } = useAuth();
+  const { currentUser, loading: authLoading } = useAuth();
   const { markFeedSeen } = useNotifications();
   const [feedItems, setFeedItems] = useState<BathEntry[]>([]);
   const [feedLoading, setFeedLoading] = useState(true);
+  const [signupsByBathId, setSignupsByBathId] = useState<Map<string, BathSignup[]>>(new Map());
+  const [loadingSignups, setLoadingSignups] = useState(true);
   const [openCommentsId, setOpenCommentsId] = useState<string | null>(null);
 
   useEffect(() => {
     setFeedLoading(true);
+    setLoadingSignups(true);
     const bathsCollectionRef = collection(db, "baths");
     const q = query(bathsCollectionRef, orderBy("createdAt", "desc"));
 
-    const unsubscribe = onSnapshot(q, (querySnapshot) => {
+    const unsubscribe = onSnapshot(q, async (querySnapshot) => {
       const items: BathEntry[] = [];
+      const signupPromises: Promise<{ bathId: string; signups: BathSignup[] }>[] = [];
 
-      querySnapshot.forEach((doc) => {
-        const data = doc.data() as BathEntry;
-        items.push({ ...data, id: doc.id });
-        // attendees are stored as plain names
+      querySnapshot.forEach((docSnap) => {
+        const data = docSnap.data() as BathEntry;
+        items.push({ ...data, id: docSnap.id });
+        if (data.type === "planned") {
+          signupPromises.push(
+            getBathSignups(docSnap.id)
+              .then((s) => ({ bathId: docSnap.id, signups: s }))
+              .catch((err) => {
+                console.error(`Error fetching signups for bath ${docSnap.id}:`, err);
+                return { bathId: docSnap.id, signups: [] };
+              })
+          );
+        }
       });
       setFeedItems(items);
+
+      try {
+        const signupResults = await Promise.all(signupPromises);
+        const newMap = new Map<string, BathSignup[]>();
+        signupResults.forEach((res) => newMap.set(res.bathId, res.signups));
+        setSignupsByBathId(newMap);
+      } catch (error) {
+        console.error("Error fetching some signups: ", error);
+      } finally {
+        setLoadingSignups(false);
+      }
+
       setFeedLoading(false);
     }, (error) => {
       console.error("Error fetching feed items: ", error);
       toast({ variant: "destructive", title: "Feil", description: "Kunne ikke laste feed." });
       setFeedLoading(false);
+      setLoadingSignups(false);
     });
 
     return () => unsubscribe();
   }, [toast]);
 
   useEffect(() => {
-    if (!feedLoading) {
+    if (!feedLoading && !loadingSignups) {
       markFeedSeen();
     }
-  }, [feedLoading, markFeedSeen, feedItems]);
+  }, [feedLoading, loadingSignups, markFeedSeen, feedItems]);
 
   const handleSignUp = async (plannedBathId: string, bathDescription: string) => {
-    if (!currentUser) {
+    if (!currentUser || !currentUser.displayName) {
       toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn for å melde deg på." });
       return;
     }
-    const bath = feedItems.find(
-      (b): b is PlannedBath => b.id === plannedBathId && b.type === "planned"
-    );
-    if (bath?.attendees?.includes(userProfile?.name || '')) {
+    const signups = signupsByBathId.get(plannedBathId) || [];
+    const alreadySignedUp = currentUser && signups.some(s => s.userId === currentUser.uid);
+    if (alreadySignedUp) {
       toast({
         title: "Allerede påmeldt",
         description: "Du er allerede påmeldt",
       });
       return;
     }
-    if (!userProfile) {
-      toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn." });
-      return;
-    }
     try {
-      await joinBath(plannedBathId, userProfile?.name || '');
-      // State updates via the onSnapshot listener
+      await signUpForBath(plannedBathId, currentUser.uid, currentUser.displayName!);
+      // Optimistic update
+      setSignupsByBathId(prev => {
+        const newMap = new Map(prev);
+        const current = newMap.get(plannedBathId) || [];
+        const newSignup: BathSignup = {
+          id: currentUser.uid,
+          userId: currentUser.uid,
+          displayName: currentUser.displayName!,
+          signedUpAt: Timestamp.now(),
+        };
+        newMap.set(plannedBathId, [...current, newSignup]);
+        return newMap;
+      });
       toast({
         title: "Påmeldt!",
         description: `Du er nå påmeldt "${bathDescription}".`,
@@ -104,14 +142,13 @@ export function RealTimeFeed() {
   };
 
   const handleSignOff = async (plannedBathId: string, bathDescription: string) => {
-    if (!currentUser || !userProfile) {
+    if (!currentUser) {
       toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn." });
       return;
     }
-    const bath = feedItems.find(
-      (b): b is PlannedBath => b.id === plannedBathId && b.type === "planned"
-    );
-    if (!bath?.attendees?.includes(userProfile?.name || '')) {
+    const signups = signupsByBathId.get(plannedBathId) || [];
+    const alreadySignedUp = currentUser && signups.some(s => s.userId === currentUser.uid);
+    if (!alreadySignedUp) {
       toast({
         variant: "destructive",
         title: "Ikke påmeldt",
@@ -121,7 +158,13 @@ export function RealTimeFeed() {
     }
 
     try {
-      await leaveBath(plannedBathId, userProfile?.name || '');
+      await cancelSignUp(plannedBathId, currentUser.uid);
+      setSignupsByBathId(prev => {
+        const newMap = new Map(prev);
+        const current = newMap.get(plannedBathId) || [];
+        newMap.set(plannedBathId, current.filter(s => s.userId !== currentUser.uid));
+        return newMap;
+      });
       toast({
         title: "Avmeldt!",
         description: `Du er nå avmeldt "${bathDescription}".`,
@@ -155,7 +198,7 @@ export function RealTimeFeed() {
   };
 
 
-  if (authLoading || feedLoading) {
+  if (authLoading || feedLoading || loadingSignups) {
     return (
       <div className="space-y-6">
         {Array.from({ length: 3 }).map((_, i) => (
@@ -254,12 +297,17 @@ export function RealTimeFeed() {
               <div className="space-y-2">
                 <h3 className="font-semibold text-lg flex items-center"><CalendarCheck className="h-5 w-5 mr-2 text-primary" /> {entry.description}</h3>
                 {entry.location && <p className="text-sm text-muted-foreground">Sted: {entry.location}</p>}
-                <p className="text-sm text-muted-foreground">Antall påmeldte: {entry.attendees ? entry.attendees.length : 0}</p>
-                {entry.attendees && entry.attendees.length > 0 && (
-                  <p className="text-sm text-muted-foreground">
-                    Deltakere: {entry.attendees.join(', ')}
-                  </p>
-                )}
+                {(() => {
+                  const signups = signupsByBathId.get(entry.id) || [];
+                  return (
+                    <>
+                      <p className="text-sm text-muted-foreground">Antall påmeldte: {signups.length}</p>
+                      {signups.length > 0 && (
+                        <p className="text-sm text-muted-foreground">Deltakere: {signups.map(s => s.displayName).join(', ')}</p>
+                      )}
+                    </>
+                  );
+                })()}
               </div>
             )}
           </CardContent>
@@ -307,31 +355,40 @@ export function RealTimeFeed() {
               </>
             ) : ( // Planned bath
               <div className="flex w-full justify-between items-center">
-                <div className="flex items-center text-sm text-muted-foreground">
-                  <Users className="h-4 w-4 mr-2" />
-                  <span>{entry.attendees ? entry.attendees.length : 0} påmeldt</span>
-                </div>
-                {currentUser && entry.userId === currentUser.uid ? (
-                   <Button size="sm" variant="outline" disabled>
-                     <Info className="h-4 w-4 mr-2" /> Du arrangerer
-                   </Button>
-                ) : currentUser && entry.attendees && entry.attendees.includes(userProfile?.name || '') ? (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => handleSignOff(entry.id, entry.description)}
-                  >
-                    <UserMinus className="h-4 w-4 mr-2" /> Meld deg av
-                  </Button>
-                ) : (
-                  <Button 
-                    size="sm" 
-                    onClick={() => handleSignUp(entry.id, entry.description)}
-                    disabled={!currentUser} // Disable if no user logged in
-                  >
-                    <UserPlus className="h-4 w-4 mr-2" /> Meld deg på
-                  </Button>
-                )}
+                {(() => {
+                  const signups = signupsByBathId.get(entry.id) || [];
+                  const userSignedUp = currentUser ? signups.some(s => s.userId === currentUser.uid) : false;
+                  const isOrganizer = currentUser && entry.userId === currentUser.uid;
+                  return (
+                    <>
+                      <div className="flex items-center text-sm text-muted-foreground">
+                        <Users className="h-4 w-4 mr-2" />
+                        <span>{signups.length} påmeldt</span>
+                      </div>
+                      {isOrganizer ? (
+                        <Button size="sm" variant="outline" disabled>
+                          <Info className="h-4 w-4 mr-2" /> Du arrangerer
+                        </Button>
+                      ) : userSignedUp ? (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleSignOff(entry.id, entry.description)}
+                        >
+                          <UserMinus className="h-4 w-4 mr-2" /> Meld deg av
+                        </Button>
+                      ) : (
+                        <Button
+                          size="sm"
+                          onClick={() => handleSignUp(entry.id, entry.description)}
+                          disabled={!currentUser}
+                        >
+                          <UserPlus className="h-4 w-4 mr-2" /> Meld deg på
+                        </Button>
+                      )}
+                    </>
+                  );
+                })()}
               </div>
             )}
           </CardFooter>

--- a/src/services/bath-attendance.ts
+++ b/src/services/bath-attendance.ts
@@ -1,0 +1,53 @@
+import { db } from '@/lib/firebase';
+import { doc, runTransaction } from 'firebase/firestore';
+
+/**
+ * Adds the given name to the attendees array of a bath document.
+ * Ensures only a single name is added and no other field is modified.
+ *
+ * @param bathId The id of the bath document
+ * @param name The attendee's name
+ */
+export async function joinBath(bathId: string, name: string): Promise<void> {
+  if (!name) {
+    throw new Error('User must be logged in');
+  }
+  const bathRef = doc(db, 'baths', bathId);
+  await runTransaction(db, async (tx) => {
+    const snap = await tx.get(bathRef);
+    if (!snap.exists()) {
+      throw new Error('Bath does not exist');
+    }
+    const data = snap.data();
+    const current: string[] = (data.attendees ?? []) as string[];
+    if (current.includes(name)) {
+      return;
+    }
+    tx.update(bathRef, { attendees: [...current, name] });
+  });
+}
+
+/**
+ * Removes the given name from the attendees array of a bath document.
+ *
+ * @param bathId The id of the bath document
+ * @param name The attendee name to remove
+ */
+export async function leaveBath(bathId: string, name: string): Promise<void> {
+  if (!name) {
+    throw new Error('User must be logged in');
+  }
+  const bathRef = doc(db, 'baths', bathId);
+  await runTransaction(db, async (tx) => {
+    const snap = await tx.get(bathRef);
+    if (!snap.exists()) {
+      throw new Error('Bath does not exist');
+    }
+    const data = snap.data();
+    const current: string[] = (data.attendees ?? []) as string[];
+    if (!current.includes(name)) {
+      return;
+    }
+    tx.update(bathRef, { attendees: current.filter((n) => n !== name) });
+  });
+}

--- a/src/types/bath.ts
+++ b/src/types/bath.ts
@@ -33,6 +33,7 @@ export interface LoggedBath extends BathBase {
 export interface PlannedBath extends BathBase {
   type: 'planned';
   description: string; // Title or description of the planned event
+  attendees?: string[];
 
   // invitedGuestsText is part of the form, not necessarily stored directly this way unless needed.
   // It's more of a note during creation.


### PR DESCRIPTION
## Summary
- show planned bath participants on the feed page
- keep attendee helper in `bath-attendance` service
- include optional `attendees` field for planned baths

## Testing
- `npm run lint` *(fails: failed to load SWC binary)*
- `npm run typecheck`
