### PR TITLE
Fix signup checks using profile name

### DIFF
--- a/src/components/app/real-time-feed.tsx
+++ b/src/components/app/real-time-feed.tsx
@@ -39,7 +39,7 @@ const ReactionButton: FC<{ icon: React.ElementType, count: number, label: string
 
 export function RealTimeFeed() {
   const { toast } = useToast();
-  const { currentUser, loading: authLoading } = useAuth();
+  const { currentUser, userProfile, loading: authLoading } = useAuth();
   const { markFeedSeen } = useNotifications();
   const [feedItems, setFeedItems] = useState<BathEntry[]>([]);
   const [feedLoading, setFeedLoading] = useState(true);
@@ -102,7 +102,7 @@ export function RealTimeFeed() {
   }, [feedLoading, loadingSignups, markFeedSeen, feedItems]);
 
   const handleSignUp = async (plannedBathId: string, bathDescription: string) => {
-    if (!currentUser || !currentUser.displayName) {
+    if (!currentUser || !userProfile) {
       toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn for å melde deg på." });
       return;
     }
@@ -116,7 +116,7 @@ export function RealTimeFeed() {
       return;
     }
     try {
-      await signUpForBath(plannedBathId, currentUser.uid, currentUser.displayName!);
+      await signUpForBath(plannedBathId, currentUser.uid, userProfile.name);
       // Optimistic update
       setSignupsByBathId(prev => {
         const newMap = new Map(prev);
@@ -124,7 +124,7 @@ export function RealTimeFeed() {
         const newSignup: BathSignup = {
           id: currentUser.uid,
           userId: currentUser.uid,
-          displayName: currentUser.displayName!,
+          displayName: userProfile.name,
           signedUpAt: Timestamp.now(),
         };
         newMap.set(plannedBathId, [...current, newSignup]);

--- a/src/components/app/upcoming-planned-baths.tsx
+++ b/src/components/app/upcoming-planned-baths.tsx
@@ -22,7 +22,7 @@ import { nb } from "date-fns/locale";
 
 export function UpcomingPlannedBaths() {
   const { toast } = useToast();
-  const { currentUser, loading: authLoading } = useAuth();
+  const { currentUser, userProfile, loading: authLoading } = useAuth();
   const { markPlannedSeen } = useNotifications();
   const [baths, setBaths] = useState<PlannedBath[]>([]);
   const [loadingBaths, setLoadingBaths] = useState(true);
@@ -90,12 +90,12 @@ export function UpcomingPlannedBaths() {
   }, [loadingBaths, loadingSignups, markPlannedSeen, baths]);
 
   const handleSignUp = async (bathId: string, description: string) => {
-    if (!currentUser || !currentUser.uid || !currentUser.displayName) {
+    if (!currentUser || !currentUser.uid || !userProfile) {
       toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn for å melde deg på." });
       return;
     }
     try {
-      await signUpForBath(bathId, currentUser.uid, currentUser.displayName);
+      await signUpForBath(bathId, currentUser.uid, userProfile.name);
       toast({ title: "Påmeldt!", description: `Du er nå påmeldt \"${description}\".` });
       // Optimistic update
       setSignupsByBathId(prevMap => {
@@ -106,7 +106,7 @@ export function UpcomingPlannedBaths() {
         const newSignup: BathSignup = {
           id: currentUser.uid, // doc id is the user's uid
           userId: currentUser.uid,
-          displayName: currentUser.displayName!,
+          displayName: userProfile.name,
           signedUpAt: Timestamp.now(), // Temporary, will be replaced by server value
         };
         newMap.set(bathId, [...currentSignups, newSignup]);


### PR DESCRIPTION
## Summary
- use `userProfile.name` instead of `currentUser.displayName` when signing up for a bath
- update real-time feed and upcoming planned baths to include profile data

## Testing
- `npm run lint` *(fails: fetch failed for `@next/swc-linux-x64-gnu`)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_683c271bce74832bab3f29a80afeedbf