### PR TITLE
Update README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Firebase Studio
+# Badekompis
 
 This project uses Firebase for database services but is deployed through [Vercel](https://vercel.com/).
 


### PR DESCRIPTION
## Notes
- `npm run lint` failed because it attempted to download a package, but the container lacks network access.
- `npm run typecheck` succeeded.

## Summary
- rename README heading to **Badekompis**

------
https://chatgpt.com/codex/tasks/task_b_683c2aea78a8832bb29b771ceb2e891a