### PR TITLE
Add logo image to header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
 
-import { Waves } from "lucide-react";
+import Image from "next/image";
 import { ClientLayoutWrapper } from "@/components/layout/client-layout-wrapper";
 import { AuthProvider } from "@/contexts/auth-context"; // Import AuthProvider
 import { NotificationProvider } from "@/contexts/notification-context";
@@ -40,7 +40,13 @@ export default function RootLayout({
             <header className="bg-primary text-primary-foreground py-4 px-4 md:px-8 shadow-md sticky top-0 z-40">
               <div className="container mx-auto flex items-center justify-center">
                 <div className="flex items-center gap-2 md:gap-3">
-                  <Waves className="h-8 w-8 md:h-10 md:w-10" />
+                  <Image
+                    src="https://firebasestorage.googleapis.com/v0/b/badekompis.firebasestorage.app/o/faf3f0e2ed9a26a67add530be61213ad0e2cf742ee9a43eccb9495fb66ae2295.png?alt=media&token=20095fde-626c-4cdd-9443-847e57dfe2e4"
+                    alt="Badekompis logo"
+                    width={40}
+                    height={40}
+                    className="h-8 w-8 md:h-10 md:w-10"
+                  />
                   <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
                     Badekompis
                   </h1>


### PR DESCRIPTION
## Summary
- swap Waves icon in `layout.tsx` header with logo image from Firebase storage

## Testing
- `npm run lint` *(fails: fetch failed – no network access)*
- `npm run typecheck` *(fails: Object literal may only specify known properties)*

------
https://chatgpt.com/codex/tasks/task_b_683c2f253f3c832b80ae84e1b28998a2