### PR TITLE
Update card header padding and page titles

### DIFF
--- a/src/app/logg-bad/page.tsx
+++ b/src/app/logg-bad/page.tsx
@@ -6,7 +6,7 @@ export default function LoggBadPage() {
     <div className="space-y-6">
       <Card className="shadow-lg">
         <CardHeader>
-          <CardTitle className="text-2xl font-semibold">Logg ditt siste bad!</CardTitle>
+          <CardTitle className="text-3xl font-semibold">Logg ditt siste bad!</CardTitle>
         </CardHeader>
         <CardContent>
           <BathLoggingForm />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ export default function FeedPage() {
     <div className="space-y-6">
       <Card className="shadow-lg">
         <CardHeader>
-          <CardTitle className="text-2xl font-semibold">Gruppe-Feed</CardTitle>
+          <CardTitle className="text-3xl font-semibold">Gruppe-Feed</CardTitle>
         </CardHeader>
         <CardContent>
           <RealTimeFeed />

--- a/src/app/planlagte-bad/page.tsx
+++ b/src/app/planlagte-bad/page.tsx
@@ -8,7 +8,7 @@ export default function PlannedBathsPage() {
     <div className="space-y-6">
       <Card className="shadow-lg">
         <CardHeader>
-          <CardTitle className="text-2xl font-semibold">Kommende Bad</CardTitle>
+          <CardTitle className="text-3xl font-semibold">Kommende Bad</CardTitle>
         </CardHeader>
         <CardContent>
           <UpcomingPlannedBaths />

--- a/src/app/planlegg-bad/page.tsx
+++ b/src/app/planlegg-bad/page.tsx
@@ -7,7 +7,7 @@ export default function PlanleggBadPage() {
     <div className="space-y-6">
       <Card className="shadow-lg">
         <CardHeader>
-          <CardTitle className="text-2xl font-semibold flex items-center">
+          <CardTitle className="text-3xl font-semibold flex items-center">
             <CalendarClock className="mr-3 h-7 w-7" />
             Planlegg et Nytt Bad
           </CardTitle>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1.5 p-4 sm:p-6", className)}
     {...props}
   />
 ))
@@ -50,7 +50,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-sm text-muted-foreground leading-relaxed", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## Notes
- `npm run lint` failed because Next.js tried to download the swc binary and the environment has no network access.
- `npm run typecheck` failed with an existing type error in `plan-bath-form.tsx`.

## Summary
- tweak `CardHeader` padding for mobile/desktop and relax line height in `CardDescription`
- bump main page `CardTitle` components to `text-3xl`
- update feed and planning pages to use larger titles

## Testing
- `npm run lint` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `npm run typecheck` *(fails: CreatePlannedBathDTO type error)*

------
https://chatgpt.com/codex/tasks/task_b_683c34917f18832b92d8136bf75225fa