### PR TITLE
Update heading styles

### DIFF
--- a/src/app/page/page.tsx
+++ b/src/app/page/page.tsx
@@ -3,9 +3,9 @@ export default function GenericPage() {
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">Generic Page</h1>
-      <p>This is a placeholder page for the /page route.</p>
-      <p>If you are seeing this unexpectedly, please check your navigation links or the URL you entered.</p>
-      <p>The main feed page is at the <a href="/" className="text-primary hover:underline">root path</a>.</p>
+      <p className="text-sm text-muted-foreground">This is a placeholder page for the /page route.</p>
+      <p className="text-sm text-muted-foreground">If you are seeing this unexpectedly, please check your navigation links or the URL you entered.</p>
+      <p className="text-sm text-muted-foreground">The main feed page is at the <a href="/" className="text-primary hover:underline">root path</a>.</p>
     </div>
   );
 }

--- a/src/app/profil/[userId]/page.tsx
+++ b/src/app/profil/[userId]/page.tsx
@@ -116,7 +116,7 @@ export default function UserProfilePage() {
               <AvatarFallback>{typeof user.name === 'string' ? user.name.substring(0, 2).toUpperCase() : '??'}</AvatarFallback>
             </Avatar>
             <CardTitle className="text-3xl font-bold">{user.name}</CardTitle>
-            {user.bio && <CardDescription className="mt-1 text-md">{user.bio}</CardDescription>}
+            {user.bio && <CardDescription className="mt-1">{user.bio}</CardDescription>}
           </div>
         </CardHeader>
         <CardContent>

--- a/src/app/profil/page.tsx
+++ b/src/app/profil/page.tsx
@@ -57,7 +57,7 @@ export default function ProfilPage() {
     return (
       <div className="flex flex-col items-center justify-center min-h-[calc(100vh-200px)] text-center p-6">
         <AlertTriangle className="h-12 w-12 text-destructive mb-4" />
-        <h2 className="text-xl font-semibold text-destructive mb-2">Problem med Profil</h2>
+        <h2 className="text-2xl font-semibold text-destructive mb-2">Problem med Profil</h2>
         <p className="text-muted-foreground mb-1">
           Vi kunne dessverre ikke laste profildataene dine.
         </p>


### PR DESCRIPTION
## Summary
- adjust error header style in profile page
- tweak user bio description size
- mute generic page descriptions

## Testing
- `npm run lint` *(fails: fetch failed)*
- `npm run typecheck` *(fails: Object literal may only specify known properties)*

------
https://chatgpt.com/codex/tasks/task_b_683c349477c8832bb104f465c397f6d2