### PR TITLE
Enhance button styles

### DIFF
--- a/src/components/app/bath-logging-form.tsx
+++ b/src/components/app/bath-logging-form.tsx
@@ -447,7 +447,13 @@ export function BathLoggingForm() {
                   <ImagePlus className="mr-2 h-4 w-4" /> Bildebevis (Valgfritt)
                 </FormLabel>
                 <div className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
-                  <Button type="button" variant="outline" onClick={() => fileInputRef.current?.click()} className="w-full sm:w-auto">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="lg"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="w-full sm:w-auto"
+                  >
                     <Upload className="mr-2 h-4 w-4" /> Last opp fil
                   </Button>
                   <Input
@@ -464,7 +470,13 @@ export function BathLoggingForm() {
                     }}
                     {...fieldProps}
                   />
-                  <Button type="button" variant="outline" onClick={() => setIsCameraDialogOpen(true)} className="w-full sm:w-auto">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="lg"
+                    onClick={() => setIsCameraDialogOpen(true)}
+                    className="w-full sm:w-auto"
+                  >
                     <Camera className="mr-2 h-4 w-4" /> Ta bilde
                   </Button>
                 </div>
@@ -489,7 +501,12 @@ export function BathLoggingForm() {
         <canvas ref={canvasRef} className="hidden"></canvas>
 
 
-        <Button type="submit" className="w-full md:w-auto bg-accent hover:bg-accent/90 text-accent-foreground" disabled={isSubmitting || authLoading || !currentUser}>
+        <Button
+          type="submit"
+          size="lg"
+          className="w-full md:w-auto bg-accent hover:bg-accent/90 text-accent-foreground"
+          disabled={isSubmitting || authLoading || !currentUser}
+        >
           {isSubmitting ? <Waves className="mr-2 h-5 w-5 animate-spin" /> : <Waves className="mr-2 h-5 w-5" />}
           {isSubmitting ? "Logger bad..." : "Logg Bad"}
         </Button>
@@ -524,9 +541,15 @@ export function BathLoggingForm() {
           </div>
           <DialogFooter className="sm:justify-between flex-col sm:flex-row gap-2">
             <DialogClose asChild>
-              <Button type="button" variant="outline" className="w-full sm:w-auto">Avbryt</Button>
+              <Button type="button" variant="outline" size="lg" className="w-full sm:w-auto">Avbryt</Button>
             </DialogClose>
-            <Button type="button" onClick={handleCaptureImage} disabled={!hasCameraPermission || !cameraStream || isSubmitting} className="w-full sm:w-auto">
+            <Button
+              type="button"
+              size="lg"
+              onClick={handleCaptureImage}
+              disabled={!hasCameraPermission || !cameraStream || isSubmitting}
+              className="w-full sm:w-auto"
+            >
               <Camera className="mr-2 h-4 w-4" /> Knytt Bilde
             </Button>
           </DialogFooter>

--- a/src/components/app/plan-bath-form.tsx
+++ b/src/components/app/plan-bath-form.tsx
@@ -282,7 +282,12 @@ export function PlanBathForm() {
             </FormItem>
           )}
         />
-        <Button type="submit" className="w-full md:w-auto bg-accent hover:bg-accent/90 text-accent-foreground" disabled={isSubmitting || authLoading || !currentUser}>
+        <Button
+          type="submit"
+          size="lg"
+          className="w-full md:w-auto bg-accent hover:bg-accent/90 text-accent-foreground"
+          disabled={isSubmitting || authLoading || !currentUser}
+        >
           {isSubmitting ? <Waves className="mr-2 h-5 w-5 animate-spin" /> : <Send className="mr-2 h-5 w-5" />}
           {isSubmitting ? "Planlegger..." : "Planlegg Bad"}
         </Button>

--- a/src/components/app/profile-form.tsx
+++ b/src/components/app/profile-form.tsx
@@ -250,11 +250,23 @@ export function ProfileForm({}: ProfileFormProps) {
         />
         
         <div className="flex flex-col sm:flex-row gap-3 pt-4">
-            <Button type="submit" className="w-full sm:w-auto bg-accent hover:bg-accent/90 text-accent-foreground text-base py-3 px-6" disabled={isSubmitting || loading}>
-            {isSubmitting ? <Waves className="mr-2 h-5 w-5 animate-spin" /> : <Save className="mr-2 h-5 w-5" />}
-            {isSubmitting ? "Lagrer..." : "Lagre Endringer"}
+            <Button
+              type="submit"
+              size="lg"
+              className="w-full sm:w-auto bg-accent hover:bg-accent/90 text-accent-foreground"
+              disabled={isSubmitting || loading}
+            >
+              {isSubmitting ? <Waves className="mr-2 h-5 w-5 animate-spin" /> : <Save className="mr-2 h-5 w-5" />}
+              {isSubmitting ? "Lagrer..." : "Lagre Endringer"}
             </Button>
-            <Button type="button" variant="outline" onClick={handleLogout} className="w-full sm:w-auto text-base py-3 px-6" disabled={loading || isSubmitting}>
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              onClick={handleLogout}
+              className="w-full sm:w-auto"
+              disabled={loading || isSubmitting}
+            >
                 <LogOut className="mr-2 h-5 w-5" />
                 Logg ut
             </Button>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all hover:scale-105 active:scale-95 hover:shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -21,8 +21,8 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        sm: "h-9 rounded-md px-4 py-2",
+        lg: "h-12 rounded-md px-8 py-3",
         icon: "h-10 w-10",
       },
     },


### PR DESCRIPTION
## Summary
- add hover shadow and scale effects to button component
- expand padding for `sm` and `lg` button sizes
- adopt new `lg` size in key forms

## Testing
- `npm run lint` *(fails: unable to load SWC binary due to network)*
- `npm run typecheck` *(fails: existing type errors in repository)*

------
https://chatgpt.com/codex/tasks/task_b_683c3495fc10832b926f4b20a05da055