### PR TITLE
Add leaderboard ranking with medals

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -79,13 +79,14 @@ export default function LeaderboardPage() {
         <CardContent className="space-y-4">
           {leaderboardData.length > 0 ? (
             leaderboardData.map((user, index) => (
-            <UserProgress 
-              key={user.uid || index} 
+            <UserProgress
+              key={user.uid || index}
+              rank={index + 1}
               userId={user.uid}
-              userName={user.name} 
-              currentBaths={user.currentBaths} 
+              userName={user.name}
+              currentBaths={user.currentBaths}
               targetBaths={user.targetBaths}
-              userAvatar={user.avatarUrl} 
+              userAvatar={user.avatarUrl}
               className="py-3 px-2 border-b last:border-b-0"
             />
           ))

--- a/src/components/app/user-progress.tsx
+++ b/src/components/app/user-progress.tsx
@@ -4,14 +4,16 @@ import { Progress } from "@/components/ui/progress";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
+import { Medal } from "lucide-react";
 
 interface UserProgressProps {
   userId?: string; // Optional: for linking to profile
   userName: string;
-  userAvatar?: string; 
+  userAvatar?: string;
   currentBaths: number;
   targetBaths: number;
   className?: string;
+  rank?: number;
 }
 
 export function UserProgress({
@@ -21,11 +23,31 @@ export function UserProgress({
   currentBaths,
   targetBaths,
   className,
+  rank,
 }: UserProgressProps) {
   const progressPercentage = Math.min((currentBaths / targetBaths) * 100, 100);
 
+  const rankIndicator =
+    rank !== undefined ? (
+      rank <= 3 ? (
+        <Medal
+          className={cn(
+            "h-5 w-5",
+            rank === 1
+              ? "text-yellow-500"
+              : rank === 2
+              ? "text-gray-400"
+              : "text-amber-700"
+          )}
+        />
+      ) : (
+        <span className="text-sm font-semibold w-5 text-center">{rank}</span>
+      )
+    ) : null;
+
   const UserInfo = () => (
     <div className="flex items-center space-x-3">
+      {rankIndicator}
       {userAvatar ? (
         <Avatar className="h-10 w-10">
           <AvatarImage src={userAvatar} alt={userName} data-ai-hint="brukeravatar"/>
@@ -46,7 +68,13 @@ export function UserProgress({
   );
 
   return (
-    <div className={cn("flex flex-col space-y-3 p-1", className)}>
+    <div
+      className={cn(
+        "flex flex-col space-y-3 p-1",
+        rank !== undefined && rank <= 3 && "bg-accent/20 rounded-md",
+        className,
+      )}
+    >
       {userId ? (
          <Link href={`/profil/${userId}`} passHref legacyBehavior>
             <a className="hover:opacity-80 transition-opacity">

--- a/src/types/bath.ts
+++ b/src/types/bath.ts
@@ -34,6 +34,8 @@ export interface PlannedBath extends BathBase {
   type: 'planned';
   description: string; // Title or description of the planned event
 
+  attendees: string[]; // User IDs attending the bath
+
   // invitedGuestsText is part of the form, not necessarily stored directly this way unless needed.
   // It's more of a note during creation.
 }


### PR DESCRIPTION
## Summary
- show ranking numbers in the leaderboard
- highlight the top three with medal icons
- support optional rank prop in `UserProgress`
- fix type error by adding `attendees` field in `PlannedBath`

## Testing
- `npm run lint` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_683c34977054832bb63ff6f42ae51429