### PR TITLE
Adjust layout and card padding

### DIFF
--- a/src/components/layout/client-layout-wrapper.tsx
+++ b/src/components/layout/client-layout-wrapper.tsx
@@ -14,7 +14,7 @@ export function ClientLayoutWrapper({ children }: { children: ReactNode }) {
 
   return (
     <>
-      <main className="flex-grow container mx-auto p-4 md:p-6 pb-24"> {/* pb-24 for Navbar space */}
+      <main className="flex-grow container mx-auto p-3 sm:p-6 pb-24"> {/* pb-24 for Navbar space */}
         {children}
       </main>
       <Navbar />

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1.5 p-4 sm:p-6", className)}
     {...props}
   />
 ))
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-4 pt-0 sm:p-6", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
@@ -70,7 +70,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
+    className={cn("flex items-center p-4 pt-0 sm:p-6", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## Summary
- tweak padding for main content area
- make card component use responsive padding for mobile

## Testing
- `npm run lint` *(fails: fetch failed)*
- `npm run typecheck` *(fails: TS2353 in plan-bath-form.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_683c34999a78832b954d8f82144edf58