### PR TITLE
Add cancellation for planned baths

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,6 +44,7 @@ export default function RootLayout({
                     src="https://firebasestorage.googleapis.com/v0/b/badekompis.firebasestorage.app/o/Frame%204%201.png?alt=media&token=55e6a37b-6a7d-46c9-a044-ecc5fdf90af6"
                     width={200}
                     height={96}
+                    alt="Badekompis logo"
                     className="h-24 w-auto"
                   />
                 </div>

--- a/src/components/app/plan-bath-form.tsx
+++ b/src/components/app/plan-bath-form.tsx
@@ -108,15 +108,16 @@ export function PlanBathForm() {
     }
     setIsSubmitting(true);
 
-    const plannedBathData: CreatePlannedBathDTO = { 
+    const plannedBathData: CreatePlannedBathDTO = {
       type: 'planned',
-      userId: currentUser.uid, 
-      userName: userProfile.name, 
-      userAvatar: userProfile.avatarUrl || "", 
-      date: format(data.date, "yyyy-MM-dd"), 
+      userId: currentUser.uid,
+      userName: userProfile.name,
+      userAvatar: userProfile.avatarUrl || "",
+      date: format(data.date, "yyyy-MM-dd"),
       time: data.time,
       location: data.location,
       description: data.description,
+      attendees: [],
       createdAt: Date.now(),
     };
 

--- a/src/components/app/upcoming-planned-baths.tsx
+++ b/src/components/app/upcoming-planned-baths.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
-import { CalendarCheck, Users, UserMinus, UserPlus, Info, Waves } from "lucide-react";
+import { CalendarCheck, Users, UserMinus, UserPlus, Info, Waves, XCircle } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -15,6 +15,7 @@ import { db } from "@/lib/firebase";
 import { useNotifications } from "@/contexts/notification-context";
 import { collection, query, orderBy, onSnapshot, Timestamp } from "firebase/firestore";
 import { signUpForBath, cancelSignUp, getBathSignups } from "@/services/bath-signup";
+import { deleteBath } from "@/services/bath";
 import type { BathEntry, PlannedBath } from "@/types/bath";
 import type { BathSignup } from "@/types/signup"; // Updated import
 import { format } from "date-fns";
@@ -141,6 +142,24 @@ export function UpcomingPlannedBaths() {
     }
   };
 
+  const handleCancelBath = async (bathId: string, description: string) => {
+    if (!currentUser) {
+      toast({ variant: "destructive", title: "Logg Inn", description: "Du må være logget inn." });
+      return;
+    }
+    if (!window.confirm(`Avlyse \"${description}\"?`)) {
+      return;
+    }
+    try {
+      await deleteBath(bathId);
+      toast({ title: "Bad avlyst", description: `\"${description}\" er avlyst.` });
+      setBaths(prev => prev.filter(b => b.id !== bathId));
+    } catch (error) {
+      console.error("Error cancelling bath: ", error);
+      toast({ variant: "destructive", title: "Feil", description: "Kunne ikke avlyse badet." });
+    }
+  };
+
   const formatDateForDisplay = (dateInput: string | Timestamp) => {
     try {
       const date = dateInput instanceof Timestamp ? dateInput.toDate() : new Date(dateInput);
@@ -222,8 +241,8 @@ export function UpcomingPlannedBaths() {
                 <span>{signupsForThisBath.length} påmeldt</span>
               </div>
               {isOrganizer ? (
-                <Button size="sm" variant="outline" disabled>
-                  <Info className="h-4 w-4 mr-2" /> Du arrangerer
+                <Button size="sm" variant="destructive" onClick={() => handleCancelBath(bath.id, bath.description)}>
+                  <XCircle className="h-4 w-4 mr-2" /> Avlys
                 </Button>
               ) : isCurrentUserSignedUp ? (
                 <Button size="sm" variant="outline" onClick={() => handleSignOff(bath.id, bath.description)} disabled={!currentUser}>

--- a/src/services/bath.ts
+++ b/src/services/bath.ts
@@ -1,0 +1,13 @@
+import { db } from "@/lib/firebase";
+import { doc, deleteDoc } from "firebase/firestore";
+
+/**
+ * Deletes a bath document from Firestore.
+ * Only the creator of the bath is allowed to perform this action according to security rules.
+ *
+ * @param bathId - The ID of the bath to delete.
+ */
+export async function deleteBath(bathId: string): Promise<void> {
+  const bathDocRef = doc(db, "baths", bathId);
+  await deleteDoc(bathDocRef);
+}


### PR DESCRIPTION
## Summary
- add helper to delete baths
- support attendees array when planning baths
- set alt text for header image
- allow organizers to cancel planned baths

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Failed to load SWC binary; network required)*

------
https://chatgpt.com/codex/tasks/task_b_683c4c8c81a0832bad9de671a403ad90