### PR TITLE
Enable editing and deleting of logged baths

### DIFF
--- a/src/app/profil/[userId]/page.tsx
+++ b/src/app/profil/[userId]/page.tsx
@@ -13,7 +13,7 @@ import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth, type UserProfile } from "@/contexts/auth-context";
 import { db } from "@/lib/firebase";
-import { doc, getDoc, collection, query, where, orderBy, onSnapshot, Timestamp } from "firebase/firestore";
+import { doc, getDoc, collection, query, where, orderBy, onSnapshot, Timestamp, deleteDoc, updateDoc, increment } from "firebase/firestore";
 import { format as formatDateFns } from "date-fns";
 import { nb } from "date-fns/locale";
 import Link from "next/link";
@@ -83,6 +83,21 @@ export default function UserProfilePage() {
       return formatDateFns(date, "d. MMMM yyyy", { locale: nb });
     } catch (e) {
       return String(dateInput);
+    }
+  };
+
+  const handleDelete = async (bathId: string) => {
+    if (!loggedInUser || loggedInUser.uid !== userId) return;
+    const confirmDelete = window.confirm('Slette dette badet?');
+    if (!confirmDelete) return;
+    try {
+      await deleteDoc(doc(db, 'baths', bathId));
+      await updateDoc(doc(db, 'users', userId), { currentBaths: increment(-1) });
+      setBathLog(prev => prev.filter(b => b.id !== bathId));
+      toast({ title: 'Bad slettet' });
+    } catch (err) {
+      console.error('Error deleting bath:', err);
+      toast({ variant: 'destructive', title: 'Feil', description: 'Kunne ikke slette badet.' });
     }
   };
 
@@ -195,6 +210,14 @@ export default function UserProfilePage() {
                       </div>
                     )}
                   </CardContent>
+                  {loggedInUser && loggedInUser.uid === userId && bath.type === 'logged' && (
+                    <div className="flex justify-end gap-2 px-4 pb-4">
+                      <Link href={`/rediger-bad/${bath.id}`} className="text-sm underline text-accent">Rediger</Link>
+                      <Button variant="ghost" size="sm" className="text-destructive" onClick={() => handleDelete(bath.id)}>
+                        Slett
+                      </Button>
+                    </div>
+                  )}
                 </Card>
               ))}
             </div>

--- a/src/app/rediger-bad/[bathId]/page.tsx
+++ b/src/app/rediger-bad/[bathId]/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { BathLoggingForm } from "@/components/app/bath-logging-form";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { db } from "@/lib/firebase";
+import { doc, getDoc } from "firebase/firestore";
+import type { LoggedBath } from "@/types/bath";
+import { Waves } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+
+export default function EditBathPage() {
+  const params = useParams();
+  const bathId = params?.bathId as string | undefined;
+  const router = useRouter();
+  const { toast } = useToast();
+  const [bath, setBath] = useState<LoggedBath | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchBath = async () => {
+      if (!bathId) return;
+      const docRef = doc(db, "baths", bathId);
+      const snap = await getDoc(docRef);
+      if (snap.exists()) {
+        const data = snap.data() as LoggedBath;
+        if (data.type === "logged") {
+          setBath({ ...data, id: snap.id });
+        } else {
+          toast({ variant: "destructive", title: "Ugyldig", description: "Dette er ikke et logget bad." });
+          router.push("/");
+        }
+      } else {
+        toast({ variant: "destructive", title: "Ikke funnet", description: "Badet ble ikke funnet." });
+        router.push("/");
+      }
+      setLoading(false);
+    };
+    fetchBath();
+  }, [bathId, router, toast]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center p-8">
+        <Waves className="h-8 w-8 animate-spin" /> Laster...
+      </div>
+    );
+  }
+
+  if (!bath) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card className="shadow-lg">
+        <CardHeader>
+          <CardTitle className="text-3xl font-semibold">Rediger Bad</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <BathLoggingForm existingBath={bath} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/app/bath-logging-form.tsx
+++ b/src/components/app/bath-logging-form.tsx
@@ -46,7 +46,7 @@ import { CalendarIcon, Clock, ImagePlus, MapPin, Waves, Thermometer, Upload, Cam
 import { useToast } from "@/hooks/use-toast";
 import Image from "next/image";
 import { useState, type ChangeEvent, useEffect, useRef } from "react";
-import type { WaterTemperatureFeeling, CreateLoggedBathDTO } from "@/types/bath";
+import type { WaterTemperatureFeeling, CreateLoggedBathDTO, LoggedBath } from "@/types/bath";
 import { useAuth } from "@/contexts/auth-context";
 import { db, storage } from "@/lib/firebase";
 import { addDoc, collection, doc, updateDoc, increment, serverTimestamp } from "firebase/firestore";
@@ -87,7 +87,7 @@ const bathLoggingSchema = z.object({
 
 type BathLoggingFormValues = z.infer<typeof bathLoggingSchema>;
 
-export function BathLoggingForm() {
+export function BathLoggingForm({ existingBath }: { existingBath?: LoggedBath }) {
   const { toast } = useToast();
   const { currentUser, userProfile, loading: authLoading, fetchUserProfile } = useAuth();
   const router = useRouter();
@@ -104,14 +104,18 @@ export function BathLoggingForm() {
   // const [initialTime, setInitialTime] = useState<string>("");
 
 
+  const isEditing = !!existingBath;
+
   const form = useForm<BathLoggingFormValues>({
     resolver: zodResolver(bathLoggingSchema),
     defaultValues: {
-      date: new Date(), // Default to client's current date, will be refined in useEffect
-      time: new Date().toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit' }), // Default, refined in useEffect
-      location: "",
-      waterTemperature: undefined,
-      comments: "",
+      date: isEditing ? new Date(existingBath!.date) : new Date(),
+      time: isEditing
+        ? existingBath!.time
+        : new Date().toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit' }),
+      location: existingBath?.location || "",
+      waterTemperature: existingBath?.waterTemperature || undefined,
+      comments: existingBath?.comments || "",
       image: null,
     },
     mode: "onChange",
@@ -126,16 +130,23 @@ export function BathLoggingForm() {
   
 
   useEffect(() => {
-    // Set initial date and time on client-side after hydration
-    // This ensures it uses the client's current date/time and avoids hydration mismatch
-    const now = new Date();
-    setInitialDate(now); // For Calendar component initial display if needed
-    form.setValue('date', now, { shouldValidate: true });
-    
-    const currentTimeFormatted = now.toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit' });
-    form.setValue('time', currentTimeFormatted, { shouldValidate: true });
-
-  }, [form]); // Run only once on mount
+    if (isEditing && existingBath) {
+      const d = new Date(existingBath.date);
+      setInitialDate(d);
+      form.setValue('date', d, { shouldValidate: true });
+      form.setValue('time', existingBath.time, { shouldValidate: true });
+      form.setValue('location', existingBath.location || '', { shouldValidate: false });
+      form.setValue('waterTemperature', existingBath.waterTemperature || undefined);
+      form.setValue('comments', existingBath.comments || '', { shouldValidate: false });
+      setPreviewImage(existingBath.imageUrl || null);
+    } else {
+      const now = new Date();
+      setInitialDate(now);
+      form.setValue('date', now, { shouldValidate: true });
+      const currentTimeFormatted = now.toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit' });
+      form.setValue('time', currentTimeFormatted, { shouldValidate: true });
+    }
+  }, [form, existingBath, isEditing]);
 
 
   useEffect(() => {
@@ -182,8 +193,7 @@ export function BathLoggingForm() {
         return;
     }
     setIsSubmitting(true);
-
-    let imageUrl: string | undefined = undefined;
+    let imageUrl: string | undefined = existingBath?.imageUrl;
     if (data.image) {
         try {
             const imageFileName = `baths/${currentUser.uid}/${Date.now()}-${data.image.name}`;
@@ -198,53 +208,49 @@ export function BathLoggingForm() {
         }
     }
 
-    const bathData: CreateLoggedBathDTO = {
-        userId: currentUser.uid,
-        userName: userProfile.name,
-        userAvatar: userProfile.avatarUrl || "",
-        date: format(data.date, "yyyy-MM-dd"),
-        time: data.time,
-        location: data.location || "",
-        waterTemperature: data.waterTemperature || null,
-        comments: data.comments || "",
-        ...(imageUrl ? { imageUrl } : {}),
-        reactions: { thumbsUp: 0, heart: 0, party: 0 },
-        commentCount: 0,
-        createdAt: Date.now(),
-        type: 'logged',
-    };
-
     try {
-        await addDoc(collection(db, "baths"), bathData);
-        
-        const userDocRef = doc(db, "users", currentUser.uid);
-        await updateDoc(userDocRef, {
-            currentBaths: increment(1)
-        });
-        await fetchUserProfile(currentUser.uid);
+        if (isEditing && existingBath) {
+            const updateData: Partial<LoggedBath> = {
+                date: format(data.date, "yyyy-MM-dd"),
+                time: data.time,
+                location: data.location || "",
+                waterTemperature: data.waterTemperature || null,
+                comments: data.comments || "",
+                ...(imageUrl ? { imageUrl } : {}),
+            };
+            await updateDoc(doc(db, "baths", existingBath.id), updateData);
+            toast({ title: "Bad Oppdatert!", description: "Endringene er lagret." });
+        } else {
+            const bathData: CreateLoggedBathDTO = {
+                userId: currentUser.uid,
+                userName: userProfile.name,
+                userAvatar: userProfile.avatarUrl || "",
+                date: format(data.date, "yyyy-MM-dd"),
+                time: data.time,
+                location: data.location || "",
+                waterTemperature: data.waterTemperature || null,
+                comments: data.comments || "",
+                ...(imageUrl ? { imageUrl } : {}),
+                reactions: { thumbsUp: 0, heart: 0, party: 0 },
+                commentCount: 0,
+                createdAt: Date.now(),
+                type: 'logged',
+            };
+            await addDoc(collection(db, "baths"), bathData);
+            const userDocRef = doc(db, "users", currentUser.uid);
+            await updateDoc(userDocRef, { currentBaths: increment(1) });
+            await fetchUserProfile(currentUser.uid);
+            toast({
+                title: "Bad Logget!",
+                description: `Ditt bad ${data.location ? `ved ${data.location}` : ''} er logget.`,
+                variant: "default",
+            });
+        }
 
-
-        toast({
-            title: "Bad Logget!",
-            description: `Ditt bad ${data.location ? `ved ${data.location}` : ''} er logget.`,
-            variant: "default",
-        });
-        
-        // Reset to new current date/time for next logging
-        const now = new Date();
-        form.reset({
-            date: now,
-            time: now.toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit' }),
-            location: "",
-            waterTemperature: undefined,
-            comments: "",
-            image: undefined,
-        });
-        setPreviewImage(null);
-        router.push('/'); 
+        router.push('/');
     } catch (error) {
         console.error("Error logging bath: ", error);
-        toast({ variant: "destructive", title: "Loggføring feilet", description: "En feil oppstod." });
+        toast({ variant: "destructive", title: "Loggfeil", description: "En feil oppstod." });
     } finally {
         setIsSubmitting(false);
     }

--- a/src/components/app/real-time-feed.tsx
+++ b/src/components/app/real-time-feed.tsx
@@ -16,7 +16,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/contexts/auth-context";
 import { db } from "@/lib/firebase";
 import { useNotifications } from "@/contexts/notification-context";
-import { collection, query, orderBy, onSnapshot, doc, updateDoc, Timestamp, increment } from "firebase/firestore";
+import { collection, query, orderBy, onSnapshot, doc, updateDoc, deleteDoc, Timestamp, increment } from "firebase/firestore";
 import { getBathSignups } from '@/services/bath-signup';
 import type { BathSignup } from '@/types/signup';
 
@@ -152,6 +152,21 @@ export function RealTimeFeed() {
     }
   };
 
+  const handleDelete = async (bathId: string) => {
+    if (!currentUser) return;
+    const confirm = window.confirm('Slette dette badet?');
+    if (!confirm) return;
+    try {
+      await deleteDoc(doc(db, 'baths', bathId));
+      await updateDoc(doc(db, 'users', currentUser.uid), { currentBaths: increment(-1) });
+      setFeedItems(prev => prev.filter(item => item.id !== bathId));
+      toast({ title: 'Bad slettet' });
+    } catch (error) {
+      console.error('Error deleting bath:', error);
+      toast({ variant: 'destructive', title: 'Feil', description: 'Kunne ikke slette badet.' });
+    }
+  };
+
 
   if (authLoading || feedLoading || loadingSignups) { // Include loadingSignups
     return (
@@ -274,26 +289,38 @@ export function RealTimeFeed() {
           {entry.type === 'logged' && (
             <>
               <Separator />
-              <CardFooter className="p-2 flex justify-between items-center bg-secondary/30">
-                <ReactionButtons
-                  counts={entry.reactions}
-                  onReact={(reaction) => handleReaction(entry.id, reaction)}
-                  disabled={!currentUser}
-                />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-muted-foreground hover:text-accent"
-                  onClick={() => setOpenCommentsId(entry.id)}
-                >
-                  <MessageCircle className="h-4 w-4 mr-1" />
-                  {entry.commentCount} Kommentarer
-                </Button>
-                <CommentsDialog
-                  bathId={entry.id}
-                  open={openCommentsId === entry.id}
-                  onOpenChange={(open) => !open && setOpenCommentsId(null)}
-                />
+              <CardFooter className="p-2 flex flex-wrap justify-between items-center gap-2 bg-secondary/30">
+                <div className="flex items-center gap-2">
+                  <ReactionButtons
+                    counts={entry.reactions}
+                    onReact={(reaction) => handleReaction(entry.id, reaction)}
+                    disabled={!currentUser}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-muted-foreground hover:text-accent"
+                    onClick={() => setOpenCommentsId(entry.id)}
+                  >
+                    <MessageCircle className="h-4 w-4 mr-1" />
+                    {entry.commentCount} Kommentarer
+                  </Button>
+                  <CommentsDialog
+                    bathId={entry.id}
+                    open={openCommentsId === entry.id}
+                    onOpenChange={(open) => !open && setOpenCommentsId(null)}
+                  />
+                </div>
+                {currentUser && currentUser.uid === entry.userId && (
+                  <div className="flex gap-1">
+                    <Link href={`/rediger-bad/${entry.id}`} className="text-sm underline text-accent">
+                      Rediger
+                    </Link>
+                    <Button variant="ghost" size="sm" className="text-destructive" onClick={() => handleDelete(entry.id)}>
+                      Slett
+                    </Button>
+                  </div>
+                )}
               </CardFooter>
             </>
           )}


### PR DESCRIPTION
## Summary
- support editing logged baths in `BathLoggingForm`
- add a page at `/rediger-bad/[bathId]` for editing
- allow the owner to edit or delete baths from the feed
- allow the owner to edit or delete baths from their profile

## Testing
- `npm run lint` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `npm run typecheck` *(fails: existing type errors)*

------
https://chatgpt.com/codex/tasks/task_b_683c4c7bf308832b974fe7bb7287bff3