### PR TITLE
Fix navbar layering and missing alt text

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,6 +44,7 @@ export default function RootLayout({
                     src="https://firebasestorage.googleapis.com/v0/b/badekompis.firebasestorage.app/o/Frame%204%201.png?alt=media&token=55e6a37b-6a7d-46c9-a044-ecc5fdf90af6"
                     width={200}
                     height={96}
+                    alt="Badekompis logo"
                     className="h-24 w-auto"
                   />
                 </div>

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -36,7 +36,7 @@ export function Navbar() {
   if (loading) {
     // Optional: render a loading state or null for the navbar while auth is loading
     return (
-      <nav className="fixed bottom-0 left-0 right-0 bg-background border-t border-border shadow-t-lg z-50">
+      <nav className="fixed bottom-0 left-0 right-0 bg-background border-t border-border shadow-t-lg z-[60]">
         <div className="container mx-auto flex justify-around items-center h-16 max-w-md">
           {/* Placeholder for loading state, e.g., skeletons or a simple message */}
           <span className="text-xs text-muted-foreground">Laster...</span>
@@ -46,7 +46,7 @@ export function Navbar() {
   }
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-background border-t border-border shadow-t-lg z-50">
+    <nav className="fixed bottom-0 left-0 right-0 bg-background border-t border-border shadow-t-lg z-[60]">
       <div className="container mx-auto flex justify-around items-center h-16 max-w-md">
         {visibleNavItems.map((item) => {
           const isActive = pathname === item.href || (item.href === "/profil" && pathname.startsWith("/profil/"));


### PR DESCRIPTION
## Summary
- ensure the mobile navbar sits above overlays
- add missing alt text to header logo

## Testing
- `npm run lint` *(fails: Failed to load SWC binary)*
- `npm run typecheck` *(fails: Property 'attendees' is missing in CreatePlannedBathDTO)*

------
https://chatgpt.com/codex/tasks/task_b_6846cdcd33d4832b935b68be9877e80b